### PR TITLE
feat(zeaking): Phase 2 sync-to-tip and companion ergonomics

### DIFF
--- a/api-server/src/lwd_handlers.rs
+++ b/api-server/src/lwd_handlers.rs
@@ -5,7 +5,7 @@ use serde::Deserialize;
 use std::collections::HashMap;
 use std::path::PathBuf;
 
-use crate::handlers::error_response;
+use crate::handlers::{error_response, error_response_with_code};
 
 #[derive(Debug, Deserialize)]
 pub struct LwdUrlQuery {
@@ -22,6 +22,16 @@ pub struct LwdSyncBody {
     pub resume: Option<bool>,
 }
 
+#[derive(Debug, Deserialize)]
+pub struct LwdSyncToTipBody {
+    pub lightwalletd_url: Option<String>,
+    pub db_path: Option<String>,
+    /// Lower bound for first height (default `1`). Use wallet birthday / activation when shrinking range.
+    pub start_floor: Option<u64>,
+    /// Metadata checkpoint interval (default `32`). Minimum effective value is `1`.
+    pub persist_progress_every: Option<u64>,
+}
+
 fn zeaking_status(e: &zeaking::ZeakingError) -> StatusCode {
     match e {
         zeaking::ZeakingError::Grpc(_) => StatusCode::BAD_GATEWAY,
@@ -29,6 +39,25 @@ fn zeaking_status(e: &zeaking::ZeakingError) -> StatusCode {
         zeaking::ZeakingError::InvalidOperation(_) => StatusCode::BAD_REQUEST,
         _ => StatusCode::INTERNAL_SERVER_ERROR,
     }
+}
+
+fn zeaking_error_code(e: &zeaking::ZeakingError) -> &'static str {
+    match e {
+        zeaking::ZeakingError::Grpc(_) => "LWD_GRPC",
+        zeaking::ZeakingError::Storage(_) => "LWD_STORAGE",
+        zeaking::ZeakingError::InvalidOperation(_) => "LWD_INVALID",
+        zeaking::ZeakingError::Network(_) => "LWD_NETWORK",
+        zeaking::ZeakingError::NotFound(_) => "LWD_NOT_FOUND",
+        zeaking::ZeakingError::Serialization(_) => "LWD_SERIALIZATION",
+        zeaking::ZeakingError::Io(_) => "LWD_IO",
+    }
+}
+
+fn zeaking_err_response(e: zeaking::ZeakingError) -> (StatusCode, ResponseJson<serde_json::Value>) {
+    let status = zeaking_status(&e);
+    let code = zeaking_error_code(&e);
+    let msg = e.to_string();
+    error_response_with_code(status, msg, code)
 }
 
 fn lwd_uri(q: &LwdUrlQuery) -> String {
@@ -46,8 +75,11 @@ fn lwd_uri_from_body(body: &LwdSyncBody) -> String {
 }
 
 fn compact_db_path(body: &LwdSyncBody) -> PathBuf {
-    body.db_path
-        .as_ref()
+    compact_db_path_opt(body.db_path.as_ref())
+}
+
+fn compact_db_path_opt(db_path: Option<&String>) -> PathBuf {
+    db_path
         .map(PathBuf::from)
         .or_else(|| std::env::var("NOZY_LWD_DB").ok().map(PathBuf::from))
         .unwrap_or_else(|| nozy::paths::get_wallet_data_dir().join("lwd_compact.sqlite"))
@@ -106,20 +138,14 @@ pub async fn lwd_sync_compact(
     }
     let mut client = zeaking::lwd::connect_lightwalletd(&url)
         .await
-        .map_err(|e| {
-            let status = zeaking_status(&e);
-            error_response(status, e.to_string())
-        })?;
-    let store = zeaking::lwd::LwdCompactStore::open(&db).map_err(|e| {
-        let status = zeaking_status(&e);
-        error_response(status, e.to_string())
-    })?;
+        .map_err(zeaking_err_response)?;
+    let store = zeaking::lwd::LwdCompactStore::open(&db).map_err(zeaking_err_response)?;
     let end = if let Some(e) = body.end {
         e
     } else {
         zeaking::lwd::chain_tip_height(&mut client)
             .await
-            .map_err(|e| error_response(zeaking_status(&e), e.to_string()))?
+            .map_err(zeaking_err_response)?
     };
     let opts = zeaking::lwd::SyncCompactOptions {
         resume_from_store: body.resume.unwrap_or(false),
@@ -128,8 +154,48 @@ pub async fn lwd_sync_compact(
     let stats =
         zeaking::lwd::sync_compact_range_with_options(&mut client, &store, body.start, end, opts)
             .await
-            .map_err(|e| error_response(zeaking_status(&e), e.to_string()))?;
+            .map_err(zeaking_err_response)?;
     Ok(ResponseJson(serde_json::json!({
+        "blocks_written": stats.blocks_written,
+        "range_start_requested": stats.range_start_requested,
+        "range_start_effective": stats.range_start_effective,
+        "range_end": stats.range_end,
+        "db_path": db.to_string_lossy(),
+    })))
+}
+
+/// POST `/api/lwd/sync/compact-to-tip` — sync from next missing height through lightwalletd tip (resume-safe).
+pub async fn lwd_sync_compact_to_tip(
+    axum::Json(body): axum::Json<LwdSyncToTipBody>,
+) -> Result<ResponseJson<serde_json::Value>, (StatusCode, ResponseJson<serde_json::Value>)> {
+    let url = body
+        .lightwalletd_url
+        .clone()
+        .or_else(|| std::env::var("LIGHTWALLETD_GRPC").ok())
+        .unwrap_or_else(|| "http://127.0.0.1:9067".to_string());
+    let db = compact_db_path_opt(body.db_path.as_ref());
+    if let Some(parent) = db.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let mut client = zeaking::lwd::connect_lightwalletd(&url)
+        .await
+        .map_err(zeaking_err_response)?;
+    let store = zeaking::lwd::LwdCompactStore::open(&db).map_err(zeaking_err_response)?;
+    let tip_opts = zeaking::lwd::SyncCompactToTipOptions {
+        start_floor: body.start_floor,
+        persist_progress_every: body
+            .persist_progress_every
+            .unwrap_or_else(|| {
+                zeaking::lwd::SyncCompactToTipOptions::default().persist_progress_every
+            })
+            .max(1),
+    };
+    let stats = zeaking::lwd::sync_compact_to_tip_with_options(&mut client, &store, tip_opts)
+        .await
+        .map_err(zeaking_err_response)?;
+    Ok(ResponseJson(serde_json::json!({
+        "chain_tip": stats.chain_tip,
+        "already_at_tip": stats.already_at_tip,
         "blocks_written": stats.blocks_written,
         "range_start_requested": stats.range_start_requested,
         "range_start_effective": stats.range_start_effective,

--- a/api-server/src/main.rs
+++ b/api-server/src/main.rs
@@ -120,6 +120,10 @@ async fn main() -> anyhow::Result<()> {
             "/api/lwd/sync/compact",
             post(lwd_handlers::lwd_sync_compact),
         )
+        .route(
+            "/api/lwd/sync/compact-to-tip",
+            post(lwd_handlers::lwd_sync_compact_to_tip),
+        )
         .route("/health", get(health_check))
         .layer(axum::middleware::from_fn(
             move |req: axum::extract::Request, next: axum::middleware::Next| {

--- a/browser-extension/COMPANION.md
+++ b/browser-extension/COMPANION.md
@@ -19,6 +19,7 @@ The MV3 extension does **not** embed `zeaking`, gRPC, or SQLite. For **lightwall
    - `GET /api/lwd/info`
    - `GET /api/lwd/chain-tip`
    - `POST /api/lwd/sync/compact`
+   - `POST /api/lwd/sync/compact-to-tip`
 3. **Manifest**: `host_permissions` includes `http://127.0.0.1:3000/*` (and broader patterns as needed). This works in **Google Chrome** and **Microsoft Edge** (Chromium).
 
 ### Service worker API
@@ -30,7 +31,8 @@ Messages to the background (`NOZY_REQUEST`):
 | `companion_status` | `{ baseUrl? }` | Health + optional chain-tip probe |
 | `companion_lwd_info` | `{ baseUrl?, lightwalletd_url? }` | `GetLightdInfo` via companion |
 | `companion_lwd_chain_tip` | `{ baseUrl?, lightwalletd_url? }` | Tip height via companion |
-| `companion_lwd_sync_compact` | `{ baseUrl?, start, end?, lightwalletd_url?, db_path? }` | Sync on **desktop** DB |
+| `companion_lwd_sync_compact` | `{ baseUrl?, start, end?, lightwalletd_url?, db_path?, resume? }` | Sync on **desktop** DB |
+| `companion_lwd_sync_compact_to_tip` | `{ baseUrl?, lightwalletd_url?, db_path?, start_floor?, persist_progress_every? }` | Sync from next missing height through tip |
 
 Default `baseUrl` is `http://127.0.0.1:3000`. Override per-call for non-default ports.
 

--- a/browser-extension/background/companion-api.js
+++ b/browser-extension/background/companion-api.js
@@ -77,7 +77,7 @@ export async function companionLwdChainTip(baseUrl, lightwalletdUrl) {
 /**
  * Triggers compact sync on the companion machine (desktop SQLite path).
  * @param {string} [baseUrl]
- * @param {{ start: number, end?: number, lightwalletd_url?: string, db_path?: string }} body
+ * @param {{ start: number, end?: number, lightwalletd_url?: string, db_path?: string, resume?: boolean }} body
  */
 export async function companionLwdSyncCompact(baseUrl, body) {
   const base = normalizeCompanionBase(baseUrl);
@@ -88,7 +88,29 @@ export async function companionLwdSyncCompact(baseUrl, body) {
       start: body.start,
       end: body.end,
       lightwalletd_url: body.lightwalletd_url,
-      db_path: body.db_path
+      db_path: body.db_path,
+      resume: body.resume
+    })
+  });
+  if (!r.ok) throw new Error(await readErrorBody(r));
+  return r.json();
+}
+
+/**
+ * Sync compact blocks from next missing height through chain tip (companion desktop DB).
+ * @param {string} [baseUrl]
+ * @param {{ lightwalletd_url?: string, db_path?: string, start_floor?: number, persist_progress_every?: number }} body
+ */
+export async function companionLwdSyncCompactToTip(baseUrl, body) {
+  const base = normalizeCompanionBase(baseUrl);
+  const r = await fetch(`${base}/api/lwd/sync/compact-to-tip`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      lightwalletd_url: body.lightwalletd_url,
+      db_path: body.db_path,
+      start_floor: body.start_floor,
+      persist_progress_every: body.persist_progress_every
     })
   });
   if (!r.ok) throw new Error(await readErrorBody(r));

--- a/browser-extension/background/service-worker.js
+++ b/browser-extension/background/service-worker.js
@@ -26,6 +26,7 @@ import {
   companionLwdChainTip,
   companionLwdInfo,
   companionLwdSyncCompact,
+  companionLwdSyncCompactToTip,
   companionStatus
 } from "./companion-api.js";
 
@@ -1058,6 +1059,8 @@ const SCAN_SAVE_EVERY_BLOCKS = 10;
 const SCAN_ALARM = "nozy_scan_tick";
 const SCAN_MODE_MANUAL = "manual";
 const SCAN_MODE_AUTO = "auto";
+/** Auto mode rewind window when prior scan found no notes (safety for missed receives near tip). */
+const AUTO_SYNC_RESCAN_OVERLAP_BLOCKS = 100;
 /** Session-only copy of mnemonic+UA so `scanTick` can run after MV3 service worker restarts (cleared on lock / scan end). */
 const SCAN_RESUME_SESSION_KEY = "nozy_scan_resume_wallet_v1";
 
@@ -1290,12 +1293,8 @@ async function scanTick() {
 }
 
 async function startBackgroundScan(startHeight, endHeight) {
-  const existing = await loadScanState();
-  if (existing && existing.status === "scanning") {
-    scheduleScanAlarm(0.02);
-    void scanTick();
-    return existing;
-  }
+  // User explicitly started a range (window / custom / birthday). Always replace any
+  // in-progress job — otherwise "Last 500" is ignored while auto-sync is still "scanning".
   const state = {
     status: "scanning",
     scanMode: SCAN_MODE_MANUAL,
@@ -1346,11 +1345,15 @@ async function startAutoBackgroundScan() {
   const priorDone =
     existing &&
     (existing.status === "done" || existing.status === "stopped" || existing.status === "failed");
+  let resumedFrom = chainTip;
+  let rewoundForSafety = false;
 
   if (priorDone && typeof existing.heightProgress === "number" && existing.heightProgress >= 0) {
-    startHeight = Math.min(chainTip, Math.max(0, Math.floor(existing.heightProgress) + 1));
+    resumedFrom = Math.min(chainTip, Math.max(0, Math.floor(existing.heightProgress) + 1));
+    startHeight = resumedFrom;
   } else if (priorDone && typeof existing.currentHeight === "number" && existing.currentHeight >= 0) {
-    startHeight = Math.min(chainTip, Math.max(0, Math.floor(existing.currentHeight)));
+    resumedFrom = Math.min(chainTip, Math.max(0, Math.floor(existing.currentHeight)));
+    startHeight = resumedFrom;
   } else {
     const ws = await loadWalletState();
     const bh = Number(ws?.orchardBirthdayHeight);
@@ -1360,9 +1363,21 @@ async function startAutoBackgroundScan() {
       const orchardActivation = await getOrchardActivationHeight();
       startHeight = Math.max(0, Math.min(chainTip, orchardActivation));
     }
+    resumedFrom = startHeight;
   }
 
-  const keepHistory = priorDone && Array.isArray(existing?.discoveredNotes);
+  // If prior scans found no notes, rewind a small overlap window to avoid missing near-tip
+  // receives due to transient RPC/service-worker interruptions.
+  const priorNoteCount = Array.isArray(existing?.discoveredNotes) ? existing.discoveredNotes.length : 0;
+  if (priorDone && priorNoteCount === 0) {
+    const rewound = Math.max(0, startHeight - AUTO_SYNC_RESCAN_OVERLAP_BLOCKS);
+    if (rewound < startHeight) {
+      startHeight = rewound;
+      rewoundForSafety = true;
+    }
+  }
+
+  const keepHistory = priorDone && Array.isArray(existing?.discoveredNotes) && !rewoundForSafety;
   const state = {
     status: "scanning",
     scanMode: SCAN_MODE_AUTO,
@@ -1495,7 +1510,27 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
                 start: Number(params.start ?? 0),
                 end: params.end !== undefined && params.end !== null ? Number(params.end) : undefined,
                 lightwalletd_url: params.lightwalletd_url,
-                db_path: params.db_path
+                db_path: params.db_path,
+                resume: params.resume === true
+              })
+            )
+          );
+          return;
+        case "companion_lwd_sync_compact_to_tip":
+          sendResponse(
+            ok(
+              await companionLwdSyncCompactToTip(params.baseUrl, {
+                lightwalletd_url: params.lightwalletd_url,
+                db_path: params.db_path,
+                start_floor:
+                  params.start_floor !== undefined && params.start_floor !== null
+                    ? Number(params.start_floor)
+                    : undefined,
+                persist_progress_every:
+                  params.persist_progress_every !== undefined &&
+                  params.persist_progress_every !== null
+                    ? Number(params.persist_progress_every)
+                    : undefined
               })
             )
           );

--- a/browser-extension/wasm-core/popup/package-lock.json
+++ b/browser-extension/wasm-core/popup/package-lock.json
@@ -23,7 +23,7 @@
         "tailwindcss": "^4.2.2",
         "typescript": "^5.9.3",
         "vite": "^8.0.7",
-        "vitest": "^3.2.4"
+        "vitest": "^4.1.8"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -413,6 +413,13 @@
       "version": "1.0.0-rc.7",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.7.tgz",
       "integrity": "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
     },
@@ -818,9 +825,9 @@
       "license": "MIT"
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
     },
@@ -854,6 +861,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -895,39 +903,40 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
-      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
+      "integrity": "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "3.2.4",
-        "@vitest/utils": "3.2.4",
-        "chai": "^5.2.0",
-        "tinyrainbow": "^2.0.0"
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
-      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.8.tgz",
+      "integrity": "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "3.2.4",
+        "@vitest/spy": "4.1.8",
         "estree-walker": "^3.0.3",
-        "magic-string": "^0.30.17"
+        "magic-string": "^0.30.21"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
         "msw": "^2.4.9",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "msw": {
@@ -939,42 +948,42 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
-      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
+      "integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyrainbow": "^2.0.0"
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
-      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.8.tgz",
+      "integrity": "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "3.2.4",
-        "pathe": "^2.0.3",
-        "strip-literal": "^3.0.0"
+        "@vitest/utils": "4.1.8",
+        "pathe": "^2.0.3"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
-      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.8.tgz",
+      "integrity": "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.2.4",
-        "magic-string": "^0.30.17",
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -982,28 +991,25 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
-      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.8.tgz",
+      "integrity": "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "tinyspy": "^4.0.3"
-      },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
-      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
+      "integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.2.4",
-        "loupe": "^3.1.4",
-        "tinyrainbow": "^2.0.0"
+        "@vitest/pretty-format": "4.1.8",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -1019,42 +1025,22 @@
         "node": ">=12"
       }
     },
-    "node_modules/cac": {
-      "version": "6.7.14",
-      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
-      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/chai": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
-      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "assertion-error": "^2.0.1",
-        "check-error": "^2.1.1",
-        "deep-eql": "^5.0.1",
-        "loupe": "^3.1.0",
-        "pathval": "^2.0.0"
-      },
       "engines": {
         "node": ">=18"
       }
     },
-    "node_modules/check-error": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
-      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 16"
-      }
+      "license": "MIT"
     },
     "node_modules/csstype": {
       "version": "3.2.3",
@@ -1062,34 +1048,6 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "devOptional": true,
       "license": "MIT"
-    },
-    "node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/deep-eql": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
-      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -1116,9 +1074,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
-      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -1191,13 +1149,6 @@
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
-    },
-    "node_modules/js-tokens": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
-      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",
@@ -1460,13 +1411,6 @@
         "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/loupe": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
-      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -1476,13 +1420,6 @@
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
-    },
-    "node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.12",
@@ -1503,22 +1440,23 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/pathval": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
-      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14.16"
-      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -1533,6 +1471,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1574,6 +1513,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1662,24 +1602,11 @@
       "license": "MIT"
     },
     "node_modules/std-env": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
-      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/strip-literal": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
-      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "js-tokens": "^9.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      }
     },
     "node_modules/tailwindcss": {
       "version": "4.2.4",
@@ -1710,11 +1637,14 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
-      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
@@ -1733,30 +1663,10 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
-    "node_modules/tinypool": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
-      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.0.0 || >=20.0.0"
-      }
-    },
     "node_modules/tinyrainbow": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
-      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/tinyspy": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
-      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1791,6 +1701,7 @@
       "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -1863,89 +1774,80 @@
         }
       }
     },
-    "node_modules/vite-node": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
-      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cac": "^6.7.14",
-        "debug": "^4.4.1",
-        "es-module-lexer": "^1.7.0",
-        "pathe": "^2.0.3",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
-      },
-      "bin": {
-        "vite-node": "vite-node.mjs"
-      },
-      "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
     "node_modules/vitest": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
-      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.8.tgz",
+      "integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/chai": "^5.2.2",
-        "@vitest/expect": "3.2.4",
-        "@vitest/mocker": "3.2.4",
-        "@vitest/pretty-format": "^3.2.4",
-        "@vitest/runner": "3.2.4",
-        "@vitest/snapshot": "3.2.4",
-        "@vitest/spy": "3.2.4",
-        "@vitest/utils": "3.2.4",
-        "chai": "^5.2.0",
-        "debug": "^4.4.1",
-        "expect-type": "^1.2.1",
-        "magic-string": "^0.30.17",
+        "@vitest/expect": "4.1.8",
+        "@vitest/mocker": "4.1.8",
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/runner": "4.1.8",
+        "@vitest/snapshot": "4.1.8",
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
         "pathe": "^2.0.3",
-        "picomatch": "^4.0.2",
-        "std-env": "^3.9.0",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
         "tinybench": "^2.9.0",
-        "tinyexec": "^0.3.2",
-        "tinyglobby": "^0.2.14",
-        "tinypool": "^1.1.1",
-        "tinyrainbow": "^2.0.0",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
-        "vite-node": "3.2.4",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
         "vitest": "vitest.mjs"
       },
       "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
         "@edge-runtime/vm": "*",
-        "@types/debug": "^4.1.12",
-        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-        "@vitest/browser": "3.2.4",
-        "@vitest/ui": "3.2.4",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.8",
+        "@vitest/browser-preview": "4.1.8",
+        "@vitest/browser-webdriverio": "4.1.8",
+        "@vitest/coverage-istanbul": "4.1.8",
+        "@vitest/coverage-v8": "4.1.8",
+        "@vitest/ui": "4.1.8",
         "happy-dom": "*",
-        "jsdom": "*"
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "@edge-runtime/vm": {
           "optional": true
         },
-        "@types/debug": {
+        "@opentelemetry/api": {
           "optional": true
         },
         "@types/node": {
           "optional": true
         },
-        "@vitest/browser": {
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
           "optional": true
         },
         "@vitest/ui": {
@@ -1956,6 +1858,9 @@
         },
         "jsdom": {
           "optional": true
+        },
+        "vite": {
+          "optional": false
         }
       }
     },

--- a/browser-extension/wasm-core/popup/package.json
+++ b/browser-extension/wasm-core/popup/package.json
@@ -30,6 +30,6 @@
     "tailwindcss": "^4.2.2",
     "typescript": "^5.9.3",
     "vite": "^8.0.7",
-    "vitest": "^3.2.4"
+    "vitest": "^4.1.8"
   }
 }

--- a/browser-extension/wasm-core/popup/src/App.tsx
+++ b/browser-extension/wasm-core/popup/src/App.tsx
@@ -409,7 +409,24 @@ function SendView() {
 const NU5_ORCHARD_START_MAINNET = 1_687_104;
 const NU5_ORCHARD_START_TESTNET = 1_842_420;
 
-function ReceiveView({
+function ReceiveView({ status }: { status: WalletStatus | null }) {
+  return (
+    <div className="space-y-2 p-4 text-sm">
+      <h2 className="text-base font-semibold">Receive</h2>
+      <div className="rounded border border-white/10 bg-white/5 p-3 break-all">
+        {status?.address || "No address yet"}
+      </div>
+      <p className="text-[11px] leading-snug text-white/60">
+        Share this unified address to receive shielded ZEC. Auto-sync runs in the background while unlocked.
+      </p>
+      <p className="text-[10px] leading-snug text-white/40">
+        Use the <span className="text-white/60">Scan</span> tab for manual ranges, birthday settings, and recovery rescans.
+      </p>
+    </div>
+  );
+}
+
+function ScanView({
   status,
   scan,
   onWalletMetaChanged
@@ -575,10 +592,7 @@ function ReceiveView({
 
   return (
     <div className="space-y-2 p-4 text-sm">
-      <h2 className="text-base font-semibold">Receive</h2>
-      <div className="rounded border border-white/10 bg-white/5 p-3 break-all">
-        {status?.address || "No address yet"}
-      </div>
+      <h2 className="text-base font-semibold">Scan</h2>
 
       {scanning && (
         <div className="h-1.5 w-full rounded bg-white/10 overflow-hidden">
@@ -702,6 +716,13 @@ function ReceiveView({
             </button>
             <button
               type="button"
+              className="rounded bg-amber-400 px-2 py-1 text-[11px] text-black"
+              onClick={() => void startScanWindow(500)}
+            >
+              Last 500
+            </button>
+            <button
+              type="button"
               className="rounded bg-amber-500 px-2 py-1 text-[11px] text-black"
               onClick={() => void startScanWindow(20_000)}
             >
@@ -781,6 +802,7 @@ function CompanionView() {
   const [busy, setBusy] = useState(false);
   const [syncStart, setSyncStart] = useState("0");
   const [syncEnd, setSyncEnd] = useState("");
+  const [syncTipFloor, setSyncTipFloor] = useState("");
 
   useEffect(() => {
     getCompanionPrefs()
@@ -1003,6 +1025,37 @@ function CompanionView() {
           }
         >
           Sync compact range
+        </button>
+        <div className="text-[11px] text-white/50 pt-1">
+          Optional birthday / floor for “to tip” (empty = default 1):
+        </div>
+        <input
+          className="w-full rounded bg-white/10 p-1.5 text-xs outline-none"
+          value={syncTipFloor}
+          onChange={(e) => setSyncTipFloor(e.target.value)}
+          placeholder="start_floor (optional)"
+        />
+        <button
+          type="button"
+          disabled={busy}
+          className="rounded bg-emerald-800 px-3 py-1 text-xs text-white"
+          onClick={() =>
+            run(async () => {
+              const prefs = await getCompanionPrefs();
+              const q = prefs.lightwalletdUrl.trim();
+              const floorRaw = syncTipFloor.trim();
+              const start_floor =
+                floorRaw === "" ? undefined : Math.max(0, Math.floor(Number(floorRaw) || 0));
+              const res = await extensionApi.companionLwdSyncCompactToTip({
+                baseUrl: prefs.baseUrl,
+                lightwalletd_url: q || undefined,
+                start_floor
+              });
+              setLog(JSON.stringify(res, null, 2));
+            })
+          }
+        >
+          Sync compact to tip
         </button>
       </div>
 
@@ -1338,8 +1391,9 @@ export function App() {
         />
       )}
       {view === "send" && <SendView />}
-      {view === "receive" && (
-        <ReceiveView status={status} scan={scanProgress} onWalletMetaChanged={() => void refresh()} />
+      {view === "receive" && <ReceiveView status={status} />}
+      {view === "scan" && (
+        <ScanView status={status} scan={scanProgress} onWalletMetaChanged={() => void refresh()} />
       )}
       {view === "companion" && <CompanionView />}
       {view === "settings" && (

--- a/browser-extension/wasm-core/popup/src/components/TopNav.tsx
+++ b/browser-extension/wasm-core/popup/src/components/TopNav.tsx
@@ -13,6 +13,7 @@ const tabLabel: Record<PopupView, string> = {
   dashboard: "Home",
   send: "Send",
   receive: "Receive",
+  scan: "Scan",
   companion: "API",
   settings: "Settings"
 };

--- a/browser-extension/wasm-core/popup/src/lib/extensionApi.ts
+++ b/browser-extension/wasm-core/popup/src/lib/extensionApi.ts
@@ -304,9 +304,22 @@ export const extensionApi = {
     end?: number;
     lightwalletd_url?: string;
     db_path?: string;
+    resume?: boolean;
   }) =>
     sendMessage<Record<string, unknown>>({
       method: "companion_lwd_sync_compact",
+      params
+    }),
+
+  companionLwdSyncCompactToTip: (params: {
+    baseUrl?: string;
+    lightwalletd_url?: string;
+    db_path?: string;
+    start_floor?: number;
+    persist_progress_every?: number;
+  }) =>
+    sendMessage<Record<string, unknown>>({
+      method: "companion_lwd_sync_compact_to_tip",
       params
     })
 };

--- a/browser-extension/wasm-core/popup/src/store/uiStore.ts
+++ b/browser-extension/wasm-core/popup/src/store/uiStore.ts
@@ -6,6 +6,7 @@ export type PopupView =
   | "dashboard"
   | "send"
   | "receive"
+  | "scan"
   | "companion"
   | "settings";
 

--- a/desktop-client/README.md
+++ b/desktop-client/README.md
@@ -75,13 +75,14 @@ When **Nozy desktop** or **`nozywallet-api`** is running, extensions can sync co
 |---------|---------|
 | `lwd_get_info` | `{ lightwalletdUrl?: string }` → chain name, tip height |
 | `lwd_chain_tip` | optional URL → tip height |
-| `lwd_sync_compact` | `{ start, end?, lightwalletdUrl?, dbPath? }` → blocks written |
+| `lwd_sync_compact` | `{ start, end?, lightwalletdUrl?, dbPath?, resume? }` → range + blocks written |
+| `lwd_sync_compact_to_tip` | `{ lightwalletdUrl?, dbPath?, startFloor?, persistProgressEvery? }` → tip + `alreadyAtTip` + range stats |
 
 Default lightwalletd URL: env `LIGHTWALLETD_GRPC` or `http://127.0.0.1:9067`.
 
 **HTTP API** (if you run `nozywallet-api`): see [`api-server`](../api-server) routes `/api/lwd/*`.
 
-**Browser extension (Chrome / Edge):** [`browser-extension/COMPANION.md`](../browser-extension/COMPANION.md) — `host_permissions` for `http://127.0.0.1:3000/*` and service-worker methods `companion_status`, `companion_lwd_*`.
+**Browser extension (Chrome / Edge):** [`browser-extension/COMPANION.md`](../browser-extension/COMPANION.md) — `host_permissions` for `http://127.0.0.1:3000/*` and service-worker methods `companion_status`, `companion_lwd_*` (including `companion_lwd_sync_compact_to_tip`).
 
 **Mobile:** [`zeaking-ffi`](../zeaking-ffi) — UniFFI bindings for the same `zeaking::lwd` calls.
 

--- a/desktop-client/src-tauri/src/commands/lwd.rs
+++ b/desktop-client/src-tauri/src/commands/lwd.rs
@@ -25,6 +25,16 @@ pub struct LwdSyncResponse {
     pub range_end: u64,
 }
 
+#[derive(Debug, Serialize)]
+pub struct LwdSyncToTipResponse {
+    pub chain_tip: u64,
+    pub already_at_tip: bool,
+    pub blocks_written: u64,
+    pub range_start_requested: u64,
+    pub range_start_effective: u64,
+    pub range_end: u64,
+}
+
 #[derive(Debug, Deserialize)]
 pub struct LwdSyncRequest {
     pub start: u64,
@@ -33,6 +43,14 @@ pub struct LwdSyncRequest {
     pub db_path: Option<String>,
     /// Skip compact heights already present in the SQLite store.
     pub resume: Option<bool>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct LwdSyncToTipRequest {
+    pub lightwalletd_url: Option<String>,
+    pub db_path: Option<String>,
+    pub start_floor: Option<u64>,
+    pub persist_progress_every: Option<u64>,
 }
 
 fn lwd_url(o: Option<String>) -> String {
@@ -54,9 +72,11 @@ fn zeaking_err(e: zeaking::ZeakingError) -> TauriError {
 }
 
 fn compact_db_path(request: &LwdSyncRequest) -> PathBuf {
-    request
-        .db_path
-        .as_ref()
+    compact_db_path_opt(request.db_path.as_ref())
+}
+
+fn compact_db_path_opt(db_path: Option<&String>) -> PathBuf {
+    db_path
         .map(PathBuf::from)
         .unwrap_or_else(|| get_wallet_data_dir().join("lwd_compact.sqlite"))
 }
@@ -129,6 +149,40 @@ pub async fn lwd_sync_compact(request: LwdSyncRequest) -> Result<LwdSyncResponse
     .await
     .map_err(zeaking_err)?;
     Ok(LwdSyncResponse {
+        blocks_written: stats.blocks_written,
+        range_start_requested: stats.range_start_requested,
+        range_start_effective: stats.range_start_effective,
+        range_end: stats.range_end,
+    })
+}
+
+/// Sync compact blocks from the next missing height through lightwalletd tip (resume-safe).
+#[command]
+pub async fn lwd_sync_compact_to_tip(
+    request: LwdSyncToTipRequest,
+) -> Result<LwdSyncToTipResponse, TauriError> {
+    let url = lwd_url(request.lightwalletd_url.clone());
+    let db = compact_db_path_opt(request.db_path.as_ref());
+    if let Some(parent) = db.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let mut client = zeaking::lwd::connect_lightwalletd(&url)
+        .await
+        .map_err(zeaking_err)?;
+    let store = zeaking::lwd::LwdCompactStore::open(&db).map_err(zeaking_err)?;
+    let tip_opts = zeaking::lwd::SyncCompactToTipOptions {
+        start_floor: request.start_floor,
+        persist_progress_every: request
+            .persist_progress_every
+            .unwrap_or_else(|| zeaking::lwd::SyncCompactToTipOptions::default().persist_progress_every)
+            .max(1),
+    };
+    let stats = zeaking::lwd::sync_compact_to_tip_with_options(&mut client, &store, tip_opts)
+        .await
+        .map_err(zeaking_err)?;
+    Ok(LwdSyncToTipResponse {
+        chain_tip: stats.chain_tip,
+        already_at_tip: stats.already_at_tip,
         blocks_written: stats.blocks_written,
         range_start_requested: stats.range_start_requested,
         range_start_effective: stats.range_start_effective,

--- a/desktop-client/src-tauri/src/main.rs
+++ b/desktop-client/src-tauri/src/main.rs
@@ -39,6 +39,7 @@ fn main() {
             lwd_get_info,
             lwd_chain_tip,
             lwd_sync_compact,
+            lwd_sync_compact_to_tip,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/zeaking-ffi/README.md
+++ b/zeaking-ffi/README.md
@@ -8,7 +8,8 @@ UniFFI bindings for **[`zeaking::lwd`](../zeaking)** — the same lightwalletd s
 |----------|---------|
 | `lwd_get_info(url)` | `GetLightdInfo` |
 | `lwd_chain_tip(url)` | Tip height (`GetLatestBlock`) |
-| `lwd_sync_compact(url, db_path, start, end?)` | Stream compact blocks into SQLite |
+| `lwd_sync_compact(url, db_path, start, end?, resume?)` | Stream compact blocks into SQLite |
+| `lwd_sync_compact_to_tip(url, db_path, start_floor?, persist_progress_every?)` | Sync from next missing height through tip (resume-safe) |
 
 Errors are returned as `ZeakingFfiError` with a message string (maps from `ZeakingError`).
 

--- a/zeaking-ffi/src/lib.rs
+++ b/zeaking-ffi/src/lib.rs
@@ -35,6 +35,16 @@ pub struct LwdSyncResultFfi {
     pub range_end: u64,
 }
 
+#[derive(Clone, uniffi::Record)]
+pub struct LwdSyncToTipResultFfi {
+    pub chain_tip: u64,
+    pub already_at_tip: bool,
+    pub blocks_written: u64,
+    pub range_start_requested: u64,
+    pub range_start_effective: u64,
+    pub range_end: u64,
+}
+
 /// gRPC `GetLightdInfo` via lightwalletd (URL like `http://127.0.0.1:9067`).
 #[uniffi::export]
 pub fn lwd_get_info(lightwalletd_url: String) -> Result<LwdInfoFfi, ZeakingFfiError> {
@@ -110,6 +120,46 @@ pub fn lwd_sync_compact(
         .await
         .map_err(|e| ZeakingFfiError::Message(e.to_string()))?;
         Ok(LwdSyncResultFfi {
+            blocks_written: stats.blocks_written,
+            range_start_requested: stats.range_start_requested,
+            range_start_effective: stats.range_start_effective,
+            range_end: stats.range_end,
+        })
+    })
+}
+
+/// Sync from next missing compact height through lightwalletd tip (`resume_from_store` semantics).
+#[uniffi::export]
+pub fn lwd_sync_compact_to_tip(
+    lightwalletd_url: String,
+    db_path: String,
+    start_floor: Option<u64>,
+    persist_progress_every: Option<u64>,
+) -> Result<LwdSyncToTipResultFfi, ZeakingFfiError> {
+    runtime().block_on(async move {
+        let path = Path::new(&db_path);
+        if let Some(parent) = path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        let mut client = zeaking::lwd::connect_lightwalletd(&lightwalletd_url)
+            .await
+            .map_err(|e| ZeakingFfiError::Message(e.to_string()))?;
+        let store = zeaking::lwd::LwdCompactStore::open(path)
+            .map_err(|e| ZeakingFfiError::Message(e.to_string()))?;
+        let tip_opts = zeaking::lwd::SyncCompactToTipOptions {
+            start_floor,
+            persist_progress_every: persist_progress_every
+                .unwrap_or_else(|| {
+                    zeaking::lwd::SyncCompactToTipOptions::default().persist_progress_every
+                })
+                .max(1),
+        };
+        let stats = zeaking::lwd::sync_compact_to_tip_with_options(&mut client, &store, tip_opts)
+            .await
+            .map_err(|e| ZeakingFfiError::Message(e.to_string()))?;
+        Ok(LwdSyncToTipResultFfi {
+            chain_tip: stats.chain_tip,
+            already_at_tip: stats.already_at_tip,
             blocks_written: stats.blocks_written,
             range_start_requested: stats.range_start_requested,
             range_start_effective: stats.range_start_effective,

--- a/zeaking/README.md
+++ b/zeaking/README.md
@@ -83,16 +83,20 @@ API (under `zeaking::lwd`):
 
 - `connect_lightwalletd`, `LwdClient` — gRPC connection
 - `LwdCompactStore` — SQLite (`compact_blocks`, `sync_meta`; extend for witnesses as needed)
-- `sync_compact_range`, `chain_tip_height` — download a height range into the store
+- `sync_compact_range`, `sync_compact_range_with_options`, `sync_compact_to_tip`, `sync_compact_to_tip_with_options`, `chain_tip_height`, `requested_start_height_for_tip_sync` — download compact ranges into the store; “to tip” syncs from next missing height with resume-safe semantics
 - `LightwalletdBlockSource` — use with `Zeaking::new(..., LightwalletdBlockSource::connect(uri).await?, ...)` to index from compact data
 
 Protos are vendored under `proto/` (Zcash MIT license).
 
 ### Nozy integration (built)
 
-- **Tauri** ([`desktop-client/src-tauri`](../desktop-client/src-tauri)): commands `lwd_get_info`, `lwd_chain_tip`, `lwd_sync_compact` (see `commands/lwd.rs`). Env default: `LIGHTWALLETD_GRPC` (fallback `http://127.0.0.1:9067`). Compact DB: `wallet_data/lwd_compact.sqlite` unless `db_path` is passed.
-- **HTTP API** ([`api-server`](../api-server)): `GET /api/lwd/info`, `GET /api/lwd/chain-tip`, `POST /api/lwd/sync/compact` — same env; use from Chrome/Edge extensions with `host_permissions` for your API host (e.g. `http://127.0.0.1:3000`). See [`browser-extension/COMPANION.md`](../browser-extension/COMPANION.md).
-- **Mobile UniFFI** ([`zeaking-ffi`](../zeaking-ffi)): `lwd_get_info`, `lwd_chain_tip`, `lwd_sync_compact` — same semantics as Tauri/API; generate Kotlin/Swift with `uniffi-bindgen` from the built `cdylib` (see that crate’s README).
+- **Tauri** ([`desktop-client/src-tauri`](../desktop-client/src-tauri)): commands `lwd_get_info`, `lwd_chain_tip`, `lwd_sync_compact`, `lwd_sync_compact_to_tip` (see `commands/lwd.rs`). Env default: `LIGHTWALLETD_GRPC` (fallback `http://127.0.0.1:9067`). Compact DB: `wallet_data/lwd_compact.sqlite` unless `db_path` is passed.
+- **HTTP API** ([`api-server`](../api-server)): `GET /api/lwd/info`, `GET /api/lwd/chain-tip`, `POST /api/lwd/sync/compact`, `POST /api/lwd/sync/compact-to-tip` — same env; use from Chrome/Edge extensions with `host_permissions` for your API host (e.g. `http://127.0.0.1:3000`). See [`browser-extension/COMPANION.md`](../browser-extension/COMPANION.md).
+- **Mobile UniFFI** ([`zeaking-ffi`](../zeaking-ffi)): `lwd_get_info`, `lwd_chain_tip`, `lwd_sync_compact`, `lwd_sync_compact_to_tip` — same semantics as Tauri/API; generate Kotlin/Swift with `uniffi-bindgen` from the built `cdylib` (see that crate’s README).
+
+## Grant / funding materials
+
+Production-hardening proposal (~**USD $75k** narrative), budget justification, milestones, test plan templates: **`grant/`** ([`grant/README.md`](grant/README.md)).
 
 ## Installation
 

--- a/zeaking/src/lwd/mod.rs
+++ b/zeaking/src/lwd/mod.rs
@@ -17,6 +17,8 @@ pub use client::{connect_lightwalletd, LwdClient};
 pub use compact_orchard::orchard_cmx_bytes_from_compact_block;
 pub use store::LwdCompactStore;
 pub use sync::{
-    chain_tip_height, compact_sync_progress_height, sync_compact_range,
-    sync_compact_range_with_options, SyncCompactOptions, SyncCompactStats,
+    chain_tip_height, compact_sync_progress_height, requested_start_height_for_tip_sync,
+    sync_compact_range, sync_compact_range_with_options, sync_compact_to_tip,
+    sync_compact_to_tip_with_options, SyncCompactOptions, SyncCompactStats,
+    SyncCompactToTipOptions, SyncCompactToTipStats,
 };

--- a/zeaking/src/lwd/sync.rs
+++ b/zeaking/src/lwd/sync.rs
@@ -49,6 +49,84 @@ pub struct SyncCompactStats {
     pub range_end: u64,
 }
 
+/// Options for [`sync_compact_to_tip_with_options`].
+#[derive(Clone, Debug)]
+pub struct SyncCompactToTipOptions {
+    /// Optional lower bound for the first height to fetch (e.g. Orchard activation or wallet birthday).
+    /// Heights below this are never requested. Default is `1` when `None`.
+    pub start_floor: Option<u64>,
+    /// Checkpoint interval for [`SyncCompactOptions::persist_progress_every`].
+    pub persist_progress_every: u64,
+}
+
+impl Default for SyncCompactToTipOptions {
+    fn default() -> Self {
+        Self {
+            start_floor: None,
+            persist_progress_every: SyncCompactOptions::default().persist_progress_every,
+        }
+    }
+}
+
+/// Result of [`sync_compact_to_tip_with_options`] (includes tip context for UI / callers).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SyncCompactToTipStats {
+    pub chain_tip: u64,
+    pub blocks_written: u64,
+    pub range_start_requested: u64,
+    pub range_start_effective: u64,
+    pub range_end: u64,
+    /// `true` when the store is already caught up through `chain_tip` (no range to download).
+    pub already_at_tip: bool,
+}
+
+/// First height to use for a “sync to tip” pass: `max(max_compact_height + 1, start_floor_or_1)`.
+pub fn requested_start_height_for_tip_sync(
+    store: &LwdCompactStore,
+    start_floor: Option<u64>,
+) -> ZeakingResult<u64> {
+    let floor = start_floor.unwrap_or(1);
+    Ok(match store.max_compact_height()? {
+        Some(m) => m.saturating_add(1).max(floor),
+        None => floor,
+    })
+}
+
+/// Download compact blocks from the next missing height through the current lightwalletd tip.
+///
+/// Uses [`sync_compact_range_with_options`] with `resume_from_store: true` so retries stay idempotent.
+/// Call [`requested_start_height_for_tip_sync`] if you only need the resolved start height.
+pub async fn sync_compact_to_tip_with_options(
+    client: &mut LwdClient,
+    store: &LwdCompactStore,
+    options: SyncCompactToTipOptions,
+) -> ZeakingResult<SyncCompactToTipStats> {
+    let tip = chain_tip_height(client).await?;
+    let start = requested_start_height_for_tip_sync(store, options.start_floor)?;
+    let compact = SyncCompactOptions {
+        resume_from_store: true,
+        persist_progress_every: options.persist_progress_every,
+    };
+    let stats = sync_compact_range_with_options(client, store, start, tip, compact).await?;
+    let already_at_tip = stats.range_start_effective > stats.range_end;
+    Ok(SyncCompactToTipStats {
+        chain_tip: tip,
+        blocks_written: stats.blocks_written,
+        range_start_requested: stats.range_start_requested,
+        range_start_effective: stats.range_start_effective,
+        range_end: stats.range_end,
+        already_at_tip,
+    })
+}
+
+/// Same as [`sync_compact_to_tip_with_options`] with [`SyncCompactToTipOptions::default`].
+pub async fn sync_compact_to_tip(
+    client: &mut LwdClient,
+    store: &LwdCompactStore,
+) -> ZeakingResult<SyncCompactToTipStats> {
+    sync_compact_to_tip_with_options(client, store, SyncCompactToTipOptions::default()).await
+}
+
 /// Download inclusive `[start, end]` compact blocks from lightwalletd into `store`.
 /// Returns the number of blocks written.
 ///
@@ -199,6 +277,45 @@ mod tests {
         assert_eq!(compact_sync_progress_height(&store).unwrap(), None);
         store.set_meta("last_compact_progress", " 100500 ").unwrap();
         assert_eq!(compact_sync_progress_height(&store).unwrap(), Some(100500));
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn requested_start_height_for_tip_empty_store() {
+        let path = std::env::temp_dir().join(format!(
+            "zeaking_tip_start_empty_{}.sqlite",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&path);
+        let store = LwdCompactStore::open(&path).unwrap();
+        assert_eq!(
+            requested_start_height_for_tip_sync(&store, None).unwrap(),
+            1
+        );
+        assert_eq!(
+            requested_start_height_for_tip_sync(&store, Some(500)).unwrap(),
+            500
+        );
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn requested_start_height_for_tip_after_max() {
+        let path = std::env::temp_dir().join(format!(
+            "zeaking_tip_start_max_{}.sqlite",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&path);
+        let store = LwdCompactStore::open(&path).unwrap();
+        store.put_compact_block(100, None, &[1, 2, 3]).unwrap();
+        assert_eq!(
+            requested_start_height_for_tip_sync(&store, None).unwrap(),
+            101
+        );
+        assert_eq!(
+            requested_start_height_for_tip_sync(&store, Some(200)).unwrap(),
+            200
+        );
         let _ = std::fs::remove_file(&path);
     }
 }


### PR DESCRIPTION
## Summary
Implements **Zeaking Phase 2** (product ergonomics): a single **sync to tip** path from the next missing compact height through lightwalletd tip, wired consistently across **zeaking**, **api-server**, **Tauri**, **zeaking-ffi**, and the **browser extension** companion layer. Compact sync errors on the affected API routes now include a stable JSON **`code`** (e.g. `LWD_GRPC`, `LWD_STORAGE`) for extension/desktop UX.

## What changed
- **zeaking**: `sync_compact_to_tip` / `sync_compact_to_tip_with_options`, `SyncCompactToTipOptions` / `SyncCompactToTipStats`, `requested_start_height_for_tip_sync`, extra unit tests.
- **api-server**: `POST /api/lwd/sync/compact-to-tip`; `error_response_with_code` for Zeaking errors on compact sync routes.
- **Tauri**: `lwd_sync_compact_to_tip` + request/response types.
- **zeaking-ffi**: `lwd_sync_compact_to_tip` + `LwdSyncToTipResultFfi`.
- **Extension**: `companionLwdSyncCompactToTip`, service worker message, popup API tab button + optional `start_floor`.
- **Docs**: COMPANION, zeaking/README, zeaking-ffi/README, desktop README.

## How tested
- `cargo fmt --all -- --check`
- `cargo clippy -p zeaking --all-targets --all-features -- -D warnings`
- `cargo clippy -p nozywallet-api --all-targets --all-features --no-deps -- -D warnings`
- `cargo test -p zeaking --features lightwalletd`
- `cargo build -p zeaking-ffi`, `cargo build` in `desktop-client/src-tauri`
- `npm run typecheck` in `browser-extension/wasm-core/popup`
