### PR TITLE
Feat/dynamic fee pilot a1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+## [2.3.0] — Priority Lane (2026-06-03)
+
+### Added
+
+- **Dynamic fee pilot (Phase A1):** client-side ZIP-317 conventional fees for Orchard sends
+- CLI `nozy send --priority` — opt-in fee multiplier ×4 (Shielded Labs pilot alignment)
+- Short transaction expiry (~2 blocks from chain tip at build time)
+- Desktop and api-server: priority flag on send and live fee estimates (replaces hardcoded slow/normal/fast ZEC amounts)
+
+### Changed
+
+- Send flows no longer rely on Zebrad `estimatefee` (unimplemented; previously fell back to 10_000 zats)
+- `transaction_history` records `priority` and `expiry_height` on pilot sends
+
+### Not in this release
+
+- Extension WASM fee alignment, expired-tx polling, speed-up rebuild, Zeaking-shared `fee_policy` (see [docs/rfcs/DYNAMIC_FEE_PHASE_A_IMPLEMENTATION.md](docs/rfcs/DYNAMIC_FEE_PHASE_A_IMPLEMENTATION.md))
+
+## [2.2.3] — Hot Lemon Pepper
+
+Prior release. See git history and [GitHub Releases](https://github.com/LEONINE-DAO/Nozy-wallet/releases).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2678,7 +2678,7 @@ checksum = "549e471b99ccaf2f89101bec68f4d244457d5a95a9c3d0672e9564124397741d"
 
 [[package]]
 name = "nozy"
-version = "2.2.3"
+version = "2.3.0"
 dependencies = [
  "aes-gcm",
  "argon2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nozy"
-version = "2.2.3"
+version = "2.3.0"
 edition = "2021"
 default-run = "nozy"
 description = "NozyWallet: A Orchard wallet built for Zebra, delivering the highest level of Zcash privacy through fully-shielded transactions and cutting-edge cryptographic security."

--- a/README.md
+++ b/README.md
@@ -338,7 +338,11 @@ Manage Orchard proving parameters for transaction creation.
 
 ```bash
 cargo run --bin nozy send --recipient "u1..." --amount 0.1
+# Opt-in priority fee (ZIP-317 standard × 4, ~2-block expiry):
+cargo run --bin nozy send --recipient "u1..." --amount 0.1 --priority
 ```
+
+Fees are computed **client-side** (ZIP-317). Zebrad does not implement `estimatefee`; the wallet no longer uses a fixed 10k zat fallback for sends.
 
 **Complete Transaction Flow Example:**
 

--- a/api-server/src/handlers.rs
+++ b/api-server/src/handlers.rs
@@ -100,6 +100,8 @@ pub struct SendTransactionRequest {
     pub amount: f64,
     pub memo: Option<String>,
     pub zebra_url: Option<String>,
+    #[serde(default)]
+    pub priority: bool,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -548,7 +550,26 @@ pub async fn send_transaction(
     let amount_zatoshis = (payload.request.amount * 100_000_000.0) as u64;
     let zebra_client = ZebraClient::new(zebra_url.clone());
 
-    let fee_zatoshis = nozy::cli_helpers::estimate_transaction_fee(&zebra_client).await;
+    let pilot = nozy::PilotSendOptions {
+        priority: payload.request.priority,
+        expiry_delta_blocks: nozy::PILOT_EXPIRY_DELTA_BLOCKS,
+    };
+    let fee_zatoshis = nozy::cli_helpers::estimate_transaction_fee_for_send(
+        &zebra_client,
+        memo_bytes_opt.as_deref(),
+        pilot.priority,
+    )
+    .await;
+
+    let tip_height = zebra_client.get_best_block_height().await.map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            ResponseJson(serde_json::json!({
+                "error": format!("Failed to read chain tip: {}", e)
+            })),
+        )
+    })?;
+    let expiry_height = tip_height.saturating_add(pilot.expiry_delta_blocks);
 
     let mut tx_builder = ZcashTransactionBuilder::new();
     tx_builder.set_zebra_url(&zebra_url);
@@ -562,6 +583,7 @@ pub async fn send_transaction(
             amount_zatoshis,
             fee_zatoshis,
             memo_bytes_opt.as_deref(),
+            pilot,
         )
         .await
         .map_err(|e| {
@@ -585,13 +607,15 @@ pub async fn send_transaction(
                     .map(|note| hex::encode(note.orchard_note.nullifier.to_bytes()))
                     .collect();
 
-                let mut tx_record = SentTransactionRecord::new(
+                let mut tx_record = SentTransactionRecord::new_pilot(
                     network_txid.clone(),
                     payload.request.recipient.clone(),
                     amount_zatoshis,
                     fee_zatoshis,
                     memo_bytes_opt.clone(),
                     spent_note_ids,
+                    pilot.priority,
+                    expiry_height,
                 );
                 tx_record.mark_broadcast();
                 let _ = tx_storage.save_transaction(tx_record);
@@ -612,18 +636,21 @@ pub async fn send_transaction(
 }
 
 pub async fn estimate_fee(
+    axum::extract::Query(params): axum::extract::Query<std::collections::HashMap<String, String>>,
 ) -> Result<ResponseJson<serde_json::Value>, (StatusCode, ResponseJson<serde_json::Value>)> {
-    use nozy::{load_config, ZebraClient};
-
-    let config = load_config();
-    let zebra_client = ZebraClient::new(config.zebra_url);
-
-    let fee_zatoshis = nozy::cli_helpers::estimate_transaction_fee(&zebra_client).await;
+    let priority = params
+        .get("priority")
+        .map(|v| v == "true" || v == "1")
+        .unwrap_or(false);
+    let fee_zatoshis = nozy::estimate_orchard_send_fee_zatoshis(None, priority);
     let fee_zec = fee_zatoshis as f64 / 100_000_000.0;
 
     Ok(ResponseJson(serde_json::json!({
         "fee_zatoshis": fee_zatoshis,
         "fee_zec": fee_zec,
+        "priority": priority,
+        "expiry_delta_blocks": nozy::PILOT_EXPIRY_DELTA_BLOCKS,
+        "fee_source": "zip317_client",
         "estimated_at": chrono::Utc::now().to_rfc3339()
     })))
 }

--- a/desktop-client/src-tauri/Cargo.lock
+++ b/desktop-client/src-tauri/Cargo.lock
@@ -3197,7 +3197,7 @@ checksum = "549e471b99ccaf2f89101bec68f4d244457d5a95a9c3d0672e9564124397741d"
 
 [[package]]
 name = "nozy"
-version = "2.2.3"
+version = "2.3.0"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3251,7 +3251,7 @@ dependencies = [
 
 [[package]]
 name = "nozywallet-desktop"
-version = "2.2.3"
+version = "2.3.0"
 dependencies = [
  "hex",
  "indexmap 1.9.3",

--- a/desktop-client/src-tauri/Cargo.toml
+++ b/desktop-client/src-tauri/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "nozywallet-desktop"
-version = "2.2.3"
+version = "2.3.0"
 edition = "2021"
 
 [dependencies]

--- a/desktop-client/src-tauri/src/commands/transaction.rs
+++ b/desktop-client/src-tauri/src/commands/transaction.rs
@@ -1,6 +1,6 @@
 use crate::error::TauriError;
 use nozy::{
-    estimate_transaction_fee, load_config, scan_notes_for_sending,
+    estimate_transaction_fee_for_send, load_config, scan_notes_for_sending,
     transaction_history::{
         SentTransactionRecord, SentTransactionStorage, TransactionStatus,
     },
@@ -14,6 +14,7 @@ fn status_key(status: &TransactionStatus) -> &'static str {
         TransactionStatus::Pending => "pending",
         TransactionStatus::Confirmed => "confirmed",
         TransactionStatus::Failed => "failed",
+        TransactionStatus::Expired => "expired",
     }
 }
 
@@ -30,6 +31,8 @@ fn tx_record_json(tx: &SentTransactionRecord) -> serde_json::Value {
         "status": status_key(&tx.status),
         "transaction_type": "sent",
         "type": "sent",
+        "priority": tx.priority,
+        "expiry_height": tx.expiry_height,
         "block_height": tx.block_height,
         "confirmations": tx.confirmations,
         "broadcast_at": tx.broadcast_at.map(|d| d.to_rfc3339()),
@@ -54,6 +57,8 @@ pub struct SendTransactionRequest {
     pub memo: Option<String>,
     pub zebra_url: Option<String>,
     pub password: Option<String>,
+    #[serde(default)]
+    pub priority: bool,
 }
 
 #[command]
@@ -101,7 +106,22 @@ pub async fn send_transaction(
     let amount_zatoshis = (request.amount * 100_000_000.0) as u64;
     let zebra_client = ZebraClient::new(zebra_url.clone());
 
-    let fee_zatoshis = estimate_transaction_fee(&zebra_client).await;
+    let pilot = nozy::PilotSendOptions {
+        priority: request.priority,
+        expiry_delta_blocks: nozy::PILOT_EXPIRY_DELTA_BLOCKS,
+    };
+    let memo_preview = request
+        .memo
+        .as_ref()
+        .map(|m| m.trim().as_bytes())
+        .filter(|b| !b.is_empty());
+    let fee_zatoshis =
+        estimate_transaction_fee_for_send(&zebra_client, memo_preview, pilot.priority).await;
+    let expiry_height = zebra_client
+        .get_best_block_height()
+        .await
+        .map_err(|e| TauriError::from(e.to_string()))?
+        .saturating_add(pilot.expiry_delta_blocks);
 
     let memo_bytes = request
         .memo
@@ -121,6 +141,7 @@ pub async fn send_transaction(
             amount_zatoshis,
             fee_zatoshis,
             memo_bytes.as_deref(),
+            pilot,
         )
         .await
         .map_err(|e| TauriError::from(e.to_string()))?;
@@ -138,13 +159,15 @@ pub async fn send_transaction(
                 .map(|note| hex::encode(note.orchard_note.nullifier.to_bytes()))
                 .collect();
 
-            let mut tx_record = SentTransactionRecord::new(
+            let mut tx_record = SentTransactionRecord::new_pilot(
                 network_txid.clone(),
                 request.recipient.clone(),
                 amount_zatoshis,
                 fee_zatoshis,
                 memo_bytes.clone(),
                 spent_note_ids,
+                pilot.priority,
+                expiry_height,
             );
             tx_record.mark_broadcast();
 
@@ -167,12 +190,16 @@ pub async fn send_transaction(
 }
 
 #[command]
-pub async fn estimate_fee(zebra_url: Option<String>) -> Result<f64, TauriError> {
+pub async fn estimate_fee(
+    zebra_url: Option<String>,
+    priority: Option<bool>,
+) -> Result<f64, TauriError> {
     let config = load_config();
     let zebra_url = zebra_url.unwrap_or_else(|| config.zebra_url.clone());
     let zebra_client = ZebraClient::new(zebra_url);
+    let priority = priority.unwrap_or(false);
 
-    let fee_zatoshis = estimate_transaction_fee(&zebra_client).await;
+    let fee_zatoshis = estimate_transaction_fee_for_send(&zebra_client, None, priority).await;
     let fee_zec = fee_zatoshis as f64 / 100_000_000.0;
 
     Ok(fee_zec)

--- a/desktop-client/src-tauri/src/lib.rs
+++ b/desktop-client/src-tauri/src/lib.rs
@@ -79,6 +79,8 @@ struct SendTransactionRequest {
     memo: Option<String>,
     zebra_url: Option<String>,
     password: Option<String>,
+    #[serde(default)]
+    priority: bool,
 }
 
 #[derive(Debug, Serialize)]
@@ -483,7 +485,26 @@ async fn send_transaction(
 
     let amount_zatoshis = (request.amount * 100_000_000.0) as u64;
     let zebra_client = nozy::ZebraClient::new(zebra_url.clone());
-    let fee_zatoshis = nozy::cli_helpers::estimate_transaction_fee(&zebra_client).await;
+    let pilot = nozy::PilotSendOptions {
+        priority: request.priority,
+        expiry_delta_blocks: nozy::PILOT_EXPIRY_DELTA_BLOCKS,
+    };
+    let memo_preview = request
+        .memo
+        .as_ref()
+        .map(|m| m.trim().as_bytes())
+        .filter(|b| !b.is_empty());
+    let fee_zatoshis = nozy::cli_helpers::estimate_transaction_fee_for_send(
+        &zebra_client,
+        memo_preview,
+        pilot.priority,
+    )
+    .await;
+    let expiry_height = zebra_client
+        .get_best_block_height()
+        .await
+        .map_err(|e| format!("Failed to read chain tip: {}", e))?
+        .saturating_add(pilot.expiry_delta_blocks);
 
     let mut tx_builder = nozy::ZcashTransactionBuilder::new();
     tx_builder.set_zebra_url(&zebra_url);
@@ -497,6 +518,7 @@ async fn send_transaction(
             amount_zatoshis,
             fee_zatoshis,
             memo_bytes_opt.as_deref(),
+            pilot,
         )
         .await
         .map_err(|e| format!("Failed to build transaction: {}", e))?;
@@ -512,13 +534,15 @@ async fn send_transaction(
                     .map(|note| hex::encode(note.orchard_note.nullifier.to_bytes()))
                     .collect();
 
-                let mut tx_record = nozy::transaction_history::SentTransactionRecord::new(
+                let mut tx_record = nozy::transaction_history::SentTransactionRecord::new_pilot(
                     network_txid.clone(),
                     request.recipient,
                     amount_zatoshis,
                     fee_zatoshis,
                     memo_bytes_opt,
                     spent_note_ids,
+                    pilot.priority,
+                    expiry_height,
                 );
                 tx_record.mark_broadcast();
                 let _ = tx_storage.save_transaction(tx_record);
@@ -539,10 +563,12 @@ async fn send_transaction(
 }
 
 #[tauri::command]
-async fn estimate_fee(zebra_url: Option<String>) -> Result<f64, String> {
+async fn estimate_fee(zebra_url: Option<String>, priority: Option<bool>) -> Result<f64, String> {
     let config = nozy::load_config();
     let client = nozy::ZebraClient::new(zebra_url.unwrap_or(config.zebra_url));
-    let fee_zatoshis = nozy::cli_helpers::estimate_transaction_fee(&client).await;
+    let priority = priority.unwrap_or(false);
+    let fee_zatoshis =
+        nozy::cli_helpers::estimate_transaction_fee_for_send(&client, None, priority).await;
     Ok(fee_zatoshis as f64 / 100_000_000.0)
 }
 

--- a/desktop-client/src/components/SendForm.tsx
+++ b/desktop-client/src/components/SendForm.tsx
@@ -9,23 +9,13 @@ import { Tooltip } from "../components/Tooltip";
 import {
   Scanner,
   InfoCircle,
-  BoltCircle,
   CheckCircle,
   User,
 } from "@solar-icons/react";
 import { useWalletStore } from "../store/walletStore";
 import { useTokenStore } from "../store/tokenStore";
 import { walletApi } from "../lib/api";
-import { cn } from "../components/Button";
 import type { AddressBookEntry } from "../lib/types";
-
-type Priority = "slow" | "normal" | "fast";
-
-const FEES = {
-  slow: 0.00004,
-  normal: 0.0002,
-  fast: 0.001,
-};
 
 interface SendFormProps {
   onSuccess?: () => void;
@@ -43,7 +33,8 @@ export function SendForm({ onSuccess, onCancel }: SendFormProps) {
   const [address, setAddress] = useState("");
   const [password, setPassword] = useState("");
   const [memo, setMemo] = useState("");
-  const [priority, setPriority] = useState<Priority>("normal");
+  const [priority, setPriority] = useState(false);
+  const [feeZec, setFeeZec] = useState(0.00015);
   const [showMemo, setShowMemo] = useState(false);
   const [showReview, setShowReview] = useState(false);
   const [isSending, setIsSending] = useState(false);
@@ -59,13 +50,26 @@ export function SendForm({ onSuccess, onCancel }: SendFormProps) {
     amount &&
     address &&
     parseFloat(amount) > 0 &&
-    parseFloat(amount) + FEES[priority] <= balance;
+    parseFloat(amount) + feeZec <= balance;
 
   useEffect(() => {
     if (pickContactOpen) {
       walletApi.listAddressBook().then((r) => setContacts(Array.isArray(r?.data) ? r.data : []));
     }
   }, [pickContactOpen]);
+
+  useEffect(() => {
+    let cancelled = false;
+    walletApi
+      .estimateFee({ priority })
+      .then((r) => {
+        if (!cancelled && typeof r?.data === "number") setFeeZec(r.data);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [priority, memo]);
 
   const handleSaveToContacts = async () => {
     const name = saveContactName.trim();
@@ -96,7 +100,7 @@ export function SendForm({ onSuccess, onCancel }: SendFormProps) {
   };
 
   const handleMax = () => {
-    const maxAmount = Math.max(0, balance - FEES[priority]);
+    const maxAmount = Math.max(0, balance - feeZec);
     setAmount(maxAmount >= 0 ? maxAmount.toString() : "0");
   };
 
@@ -111,6 +115,7 @@ export function SendForm({ onSuccess, onCancel }: SendFormProps) {
         amount: parseFloat(amount),
         memo: memo || undefined,
         password: password,
+        priority,
       });
       const txidMsg = sent.txid ? ` TXID: ${sent.txid}` : "";
       toast.success(`Transaction sent successfully!${txidMsg}`, { id: sendToast });
@@ -163,14 +168,15 @@ export function SendForm({ onSuccess, onCancel }: SendFormProps) {
               <div className="flex justify-between items-center">
                 <span className="text-gray-500 text-sm">Fee</span>
                 <span className="text-gray-900 font-medium text-sm">
-                  {FEES[priority]} {tokenSymbol}
+                  {feeZec.toFixed(8)} {tokenSymbol}
+                  {priority ? " (priority ×4)" : ""}
                 </span>
               </div>
               <div className="h-px bg-gray-200 my-2" />
               <div className="flex justify-between items-center text-base">
                 <span className="font-bold text-gray-900">Total</span>
                 <span className="font-bold text-primary-700">
-                  {(parseFloat(amount || "0") + FEES[priority]).toFixed(5)}{" "}
+                  {(parseFloat(amount || "0") + feeZec).toFixed(8)}{" "}
                   {tokenSymbol}
                 </span>
               </div>
@@ -378,45 +384,22 @@ export function SendForm({ onSuccess, onCancel }: SendFormProps) {
         )}
       </div>
 
-      <div className="space-y-3">
-        <label className="text-sm font-medium text-gray-700 ml-1">
-          Transaction Priority
+      <div className="space-y-2">
+        <label className="flex items-center justify-between gap-3 ml-1 cursor-pointer">
+          <span className="text-sm font-medium text-gray-700">
+            Priority fee (ZIP-317 × 4)
+          </span>
+          <input
+            type="checkbox"
+            checked={priority}
+            onChange={(e) => setPriority(e.target.checked)}
+            className="h-5 w-5 rounded border-gray-300 text-primary focus:ring-primary"
+          />
         </label>
-        <div className="grid grid-cols-3 gap-3">
-          {(["slow", "normal", "fast"] as Priority[]).map((p) => (
-            <button
-              key={p}
-              onClick={() => setPriority(p)}
-              className={cn(
-                "flex flex-col items-center justify-center py-2.5 rounded-xl border transition-all duration-200 relative overflow-hidden",
-                priority === p
-                  ? "bg-primary text-black border-primary shadow-md shadow-primary/20"
-                  : "bg-white/40 border-gray-200 text-gray-600 hover:border-primary/30 hover:bg-white/80"
-              )}
-            >
-              <span className="capitalize font-bold text-sm tracking-wide">
-                {p}
-              </span>
-              <span
-                className={cn(
-                  "text-[10px] mt-0.5 opacity-80",
-                  priority === p ? "text-black" : "text-gray-400"
-                )}
-              >
-                {p === "slow" ? "~20m" : p === "normal" ? "~2m" : "~0m"}
-              </span>
-              {priority === p && p === "fast" && (
-                <div className="absolute top-1 right-1">
-                  <BoltCircle
-                    size={10}
-                    weight="Bold"
-                    className="text-white"
-                  />
-                </div>
-              )}
-            </button>
-          ))}
-        </div>
+        <p className="text-xs text-gray-500 ml-1">
+          Estimated fee: {feeZec.toFixed(8)} {tokenSymbol}. Tx expires in ~2
+          minutes if not mined (pilot).
+        </p>
       </div>
 
       <div className="flex gap-3 pt-4">

--- a/desktop-client/src/lib/api.ts
+++ b/desktop-client/src/lib/api.ts
@@ -92,8 +92,14 @@ export const walletApi = {
     return { data: result };
   },
 
-  estimateFee: async (zebraUrl?: string): Promise<{ data: number }> => {
-    const result = await invoke<number>("estimate_fee", { zebra_url: zebraUrl });
+  estimateFee: async (opts?: {
+    zebraUrl?: string;
+    priority?: boolean;
+  }): Promise<{ data: number }> => {
+    const result = await invoke<number>("estimate_fee", {
+      zebra_url: opts?.zebraUrl,
+      priority: opts?.priority ?? false,
+    });
     return { data: result };
   },
 

--- a/desktop-client/src/lib/types.ts
+++ b/desktop-client/src/lib/types.ts
@@ -39,6 +39,8 @@ export interface SendTransactionRequest {
   amount: number;
   memo?: string;
   password?: string;
+  /** Pilot: ZIP-317 standard fee × 4 when true (default false). */
+  priority?: boolean;
 }
 
 export interface ConfigResponse {

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,10 @@
+# Docs
+
+| Path | Purpose |
+|------|---------|
+| [`MEMORY_CASE_STUDY.md`](MEMORY_CASE_STUDY.md) | Compact sync peak RAM (`chunk_max_blocks`), phase metrics, secrets/zeroize — **no invented RSS numbers** |
+| [`rfcs/README.md`](rfcs/README.md) | RFCs: multichain, NEAR/Secret, spikes, extension ports |
+| [`rfcs/DYNAMIC_FEE_PHASE_A_IMPLEMENTATION.md`](rfcs/DYNAMIC_FEE_PHASE_A_IMPLEMENTATION.md) | **Dynamic fee pilot — Phase A checklist** (review before coding) |
+| [`rfcs/DYNAMIC_FEE_PILOT_PLAN.md`](rfcs/DYNAMIC_FEE_PILOT_PLAN.md) | Dynamic fee pilot architecture (Shielded Labs alignment) |
+| [`ZEBRA_DEV_CLI_POSITIONING.md`](ZEBRA_DEV_CLI_POSITIONING.md) | **Positioning + roadmap:** Nozy CLI as the go-to **Zebra + Orchard** dev / debug tool |
+| [`TESTNET_CLI_WALKTHROUGH.md`](TESTNET_CLI_WALKTHROUGH.md) | **Zebrad testnet + Nozy CLI:** start node, config, sync, TZEC send |

--- a/docs/RELEASE_v2.3.0_CLI.md
+++ b/docs/RELEASE_v2.3.0_CLI.md
@@ -1,0 +1,46 @@
+# Release v2.3.0 — CLI (after merging PR #35)
+
+## Tag and publish
+
+```bash
+git checkout master
+git pull origin master
+git tag -a v2.3.0 -m "v2.3.0: ZIP-317 dynamic fees, CLI --priority"
+git push origin v2.3.0
+```
+
+GitHub Actions [release.yml](../.github/workflows/release.yml) builds and attaches:
+
+- `nozy-windows.exe`
+- `nozy-linux`
+- `nozy-macos-intel` / `nozy-macos-arm`
+- `nozywallet-api-*` (same tag)
+
+## Release notes (paste into GitHub Release)
+
+**Title:** v2.3.0 — Dynamic fee pilot (CLI)
+
+**Body:**
+
+### Summary
+
+- ZIP-317 client-side fees for Orchard sends (Zebrad has no `estimatefee`)
+- `nozy send --priority` for opt-in ×4 fee (pilot)
+- ~2-block transaction expiry at build time
+- Desktop/api-server send surfaces updated (binaries in same workflow)
+
+### CLI usage
+
+```bash
+nozy send -r u1... -a 0.1 --mainnet
+nozy send -r u1... -a 0.1 --mainnet --priority
+```
+
+### Verify
+
+- `cargo test fee_policy`
+- Testnet send with and without `--priority`; compare on-chain fee
+
+### Follow-ups
+
+Extension WASM, expiry polling, speed-up — tracked in Phase A RFC.

--- a/docs/rfcs/DYNAMIC_FEE_PHASE_A_IMPLEMENTATION.md
+++ b/docs/rfcs/DYNAMIC_FEE_PHASE_A_IMPLEMENTATION.md
@@ -1,0 +1,278 @@
+# Dynamic Fee Pilot — Phase A implementation plan (review)
+
+**Status:** A1 shipped in **v2.3.0** (CLI + api-server + desktop native surfaces); speed-up / Expired polling / extension WASM next  
+**Parent RFC:** [DYNAMIC_FEE_PILOT_PLAN.md](DYNAMIC_FEE_PILOT_PLAN.md) (architecture + Shielded Labs pilot alignment)  
+**Stack:** Zebrad-only + lightwalletd via Zeaking for sync; **no `zcashd`**
+
+This document is the **actionable checklist** for Phase A. It reflects the post–working-session decision:
+
+> **Start pilot behavior in the NozyWallet core and surfaces first.**  
+> **Defer all Zeaking crate work** (`fee_policy`, observatory, compact-stream expiry detection) **until Shielded Labs gives the go-ahead** to land shared logic in Zeaking.
+
+---
+
+## 1. What we are building (pilot features)
+
+From Shielded Labs’ “Zcash Dynamic Fees, Now!” pilot — three user-visible behaviors:
+
+| # | Feature | User sees | On-chain effect |
+|---|---------|-----------|-----------------|
+| 1 | **Opt-in priority** | Toggle (off by default) | Fee = standard × **4** when on |
+| 2 | **Short expiry** | Tx expires in ~2 minutes if not mined | `expiry_height = tip + 2` (not ~40 blocks) |
+| 3 | **Speed up** | Button after expiry | **New** tx at 4× fee + new expiry — **not** rebroadcast of same bytes |
+
+**Why we can ship without node changes:** fees are computed **client-side** (ZIP-317); 2-block expiry is valid on Zebrad (see parent RFC §1–2).
+
+---
+
+## 2. Current codebase vs target (honest snapshot)
+
+| Area | Today | Target (Phase A) |
+|------|--------|------------------|
+| Fee source | `estimatefee` RPC → almost always **10_000 zat** fallback on Zebrad | **ZIP-317** conventional fee in **nozy** `fee_policy` (interim; move to Zeaking later) |
+| Desktop send UI | Slow / Normal / Fast with **hardcoded ZEC** amounts — **not sent to backend** | Single **priority** toggle; fee from `fee_policy` at build time |
+| Expiry | `DEFAULT_TX_EXPIRY_DELTA` (~40 blocks) in `orchard_tx.rs` | Pilot default **2 blocks** (configurable constant) |
+| Extension WASM | Fixed fee zats + library default expiry | Plumb **priority**, **expiry_delta**, fee from same policy as core |
+| Extension speed-up | `retryBroadcastById` rebroadcasts **same** raw tx | Rebuild via core intent (recipient, amount, memo) |
+| History | `Pending` / `Confirmed` / `Failed` only | Add **`Expired`**; release pending balance when expiry passes unmined |
+| Zeaking | Sync/index only | **No pilot changes until SL approval** |
+
+---
+
+## 3. Scope split: what we do now vs what waits
+
+### Phase A1 — **Nozy core + surfaces** (start here)
+
+No changes under `zeaking/` until Shielded Labs approves shared-crate work.
+
+| Workstream | Primary location | Notes |
+|------------|------------------|--------|
+| **`fee_policy` (interim in nozy)** | `src/fee_policy.rs` (new) | ZIP-317 standard fee + `PRIORITY_MULTIPLIER = 4`; replace `cli_helpers::estimate_transaction_fee` → `get_fee_estimate` |
+| **Apply fee + expiry at build** | `src/orchard_tx.rs`, `src/transaction_builder.rs` | `BuildOptions { priority, expiry_delta }`; stop using broken RPC path for sends |
+| **`Expired` + balance release** | `src/transaction_history.rs` | New status; pending notes unlocked when expiry passed and tx never confirmed |
+| **Expiry / confirm polling (interim)** | `src/transaction_history.rs` or small `src/tx_lifecycle.rs` | Poll Zebrad `getrawtransaction` / tip height — **not** Zeaking compact detection yet |
+| **Speed-up rebuild** | `src/orchard_tx.rs` + history linking | New tx from stored intent; mark original `Expired` |
+| **Wire priority on all surfaces** | CLI, api-server, desktop Tauri, extension | See §5 file list |
+| **Local pilot metrics (counts only)** | e.g. `src/pilot_metrics.rs` or extend `local_analytics` | Opt-in counters: `priority_sends`, `speed_ups`, `expired_unmined`, `speed_up_confirmed` |
+| **Docs / UX copy** | Send flows | Opt-in priority; short expiry disclaimer; fingerprinting note (parent RFC §4.3) |
+
+**Testnet first** for every item before mainnet.
+
+### Phase A2 — **Zeaking** (blocked on Shielded Labs go-ahead)
+
+Do **not** start until SL confirms Zeaking as the home for shared pilot primitives.
+
+| Workstream | Primary location | Notes |
+|------------|------------------|--------|
+| Move `fee_policy` into Zeaking | `zeaking/src/fee_policy.rs` | Single source for CLI, api, desktop, FFI, extension WASM |
+| Confirmation / expiry from compact sync | `zeaking/src/lwd/…` | Feed `Expired` without per-wallet RPC polling |
+| Observatory indexer | `zeaking` + SQLite `observatory` table | Full-tx fetch for ecosystem fee/expiry stats |
+| Optional: `CompactTx.fee` | lightwalletd ask (coordination with SL) | Reduces full-tx fetch cost |
+
+After A2: delete interim duplicate in nozy and call `zeaking::fee_policy` everywhere.
+
+### How A1 adds dynamic fees **without** Zeaking
+
+Zeaking’s job today is **compact sync only** (lightwalletd → SQLite → scan). That stays unchanged in A1. Dynamic fees do **not** need the indexer; they need **math at tx build time** and **wallet state** for expiry/speed-up — both already live in the `nozy` crate.
+
+```mermaid
+flowchart LR
+    subgraph Surfaces["Surfaces — pass priority: bool"]
+        CLI[CLI / send_zec]
+        API[api-server]
+        DESK[Desktop Tauri]
+        EXT[Extension JS]
+    end
+
+    subgraph NozyCore["nozy core — Phase A1 (all new logic here)"]
+        FP["fee_policy.rs<br/>ZIP-317 + x4 priority"]
+        OTX["orchard_tx.rs<br/>fee + 2-block expiry"]
+        HIST["transaction_history.rs<br/>Expired, intent, release balance"]
+        LIFE["tx_lifecycle.rs optional<br/>poll Zebrad for confirm/expiry"]
+        ZEB["ZebraClient<br/>broadcast + getrawtransaction"]
+    end
+
+    subgraph Zeaking["Zeaking — unchanged in A1"]
+        SYNC["lwd sync only<br/>notes / witnesses"]
+    end
+
+    Surfaces -->|priority, amount, recipient| OTX
+    OTX --> FP
+    OTX --> ZEB
+    HIST --> LIFE
+    LIFE --> ZEB
+    SYNC -.->|spendable notes| OTX
+```
+
+**Step-by-step (one send):**
+
+1. **User toggles priority** on desktop / CLI / API / extension → `priority: false | true` (default `false`).
+2. **Fee preview** — surfaces call `nozy::fee_policy::fee_for_tx_shape(shape, priority)` (sync, no RPC). Same function used at build time so UI matches chain.
+3. **Build tx** — `orchard_tx` asks `fee_policy` for zats, sets `expiry_height = tip + 2`, builds Orchard bundle (existing path).
+4. **Broadcast** — `ZebraClient::sendrawtransaction` (already in nozy).
+5. **History** — save `SentTransactionRecord` with `fee_zatoshis`, `expiry_height`, `priority`, recipient, amount, memo (intent for speed-up).
+6. **Later** — `tx_lifecycle` (or history refresh): if `tip > expiry_height` and tx not in chain → `Expired`, release spent notes from “pending” lock.
+
+**What we stop using for sends:**
+
+| Old path | A1 replacement |
+|----------|----------------|
+| `ZebraClient::get_fee_estimate()` / `estimatefee` | `fee_policy` (ZIP-317 in nozy) |
+| Desktop `FEES.slow/normal/fast` constants | Live zats from `fee_policy` + priority toggle |
+| Extension `estimateFeeZats()` RPC | Same `fee_policy` via api-server or duplicated ZIP-317 in WASM build args |
+
+**Zeaking is still used for** scanning notes and witnesses — not for fees. **Phase A2** only *moves* `fee_policy` (and optionally expiry detection) into Zeaking so FFI/extension/desktop share one crate; behavior stays the same.
+
+### Phase B — After Shielded Labs standardization
+
+Unchanged from parent RFC §5: canonical “standard fee” definition, shared metrics schema, optional compact `fee` field.
+
+---
+
+## 4. Recommended build order (A1 only)
+
+```text
+1. fee_policy (ZIP-317) + unit tests
+      ↓
+2. orchard_tx: BuildOptions (priority, expiry_delta) + use fee_policy
+      ↓
+3. transaction_history: Expired + expiry_height on record + release pending notes
+      ↓
+4. tx lifecycle: detect confirmed / expired_unmined (Zebrad poll)
+      ↓
+5. speed_up() rebuild path in core + history link (successor txid)
+      ↓
+6. Surfaces: priority flag + live fee estimate endpoint/command
+      ↓
+7. Extension: WASM expiry_delta + replace retryBroadcastById
+      ↓
+8. Pilot metrics (counts only) + testnet soak
+```
+
+---
+
+## 5. File touch list (A1)
+
+### New files (proposed)
+
+| File | Purpose |
+|------|---------|
+| `src/fee_policy.rs` | `TxShape`, `standard_fee()`, `fee_for(priority)`, ZIP-317 |
+| `src/pilot_metrics.rs` (optional) | Local counters, no PII |
+| `docs/rfcs/DYNAMIC_FEE_PHASE_A_IMPLEMENTATION.md` | This plan |
+
+### Modify — core
+
+| File | Change |
+|------|--------|
+| `src/lib.rs` | `pub mod fee_policy`; re-export helpers |
+| `src/cli_helpers.rs` | `estimate_transaction_fee` → delegate to `fee_policy` (deprecate `estimatefee` for sends) |
+| `src/orchard_tx.rs` | Pilot expiry; accept priority + fee from policy |
+| `src/transaction_builder.rs` | Thread `BuildOptions` into orchard build |
+| `src/transaction_history.rs` | `Expired`; `expiry_height`; `priority`; `speed_up_of`; release pending |
+| `src/zebra_integration.rs` | Keep `get_fee_estimate` only for diagnostics, not send path |
+
+### Modify — surfaces
+
+| File | Change |
+|------|--------|
+| `src/main.rs` | `Send { --priority }`; show ZIP-317 fee in preview |
+| `src/bin/send_zec.rs` | Same flags / options |
+| `api-server/src/handlers.rs` | Send body `priority`; fee-estimate uses `fee_policy` |
+| `desktop-client/src/components/SendForm.tsx` | Replace fake tier fees with priority toggle + live estimate |
+| `desktop-client/src-tauri/src/commands/transaction.rs` | `priority` on `SendTransactionRequest` |
+| `desktop-client/src/lib/types.ts` | Types for priority + optional `estimateFee` shape |
+| `browser-extension/background/service-worker.js` | Fee from policy; pass priority |
+| `browser-extension/background/tx-lifecycle.js` | Speed-up → rebuild API, not rebroadcast |
+| `browser-extension/wasm-core/src/lib.rs` | `expiry_delta` param; fee from caller aligned with policy |
+
+---
+
+## 6. API / UX sketch (for review)
+
+### Send request (all surfaces)
+
+```json
+{
+  "recipient": "u1…",
+  "amount": 0.01,
+  "memo": "optional",
+  "priority": false
+}
+```
+
+- **`priority: false` (default)** — ZIP-317 standard fee, 2-block expiry.  
+- **`priority: true`** — fee × 4, same expiry (unless we later split “speed-up only” to post-expiry).
+
+### Fee preview
+
+`GET /api/transaction/fee-estimate?priority=false`  
+→ `{ "fee_zatoshis", "fee_zec", "priority", "expiry_delta_blocks" }`
+
+Desktop: `estimate_fee` Tauri command takes `priority: bool`.
+
+### Speed-up (after expired)
+
+`POST /api/transaction/speed-up` `{ "original_txid": "…" }`  
+→ builds new tx (priority fee, new expiry), links in history.
+
+---
+
+## 7. Constants (defaults — confirm before coding)
+
+| Constant | Proposed value | Configurable? |
+|----------|----------------|---------------|
+| `PRIORITY_MULTIPLIER` | `4` | Later; pilot likely fixed |
+| `PILOT_EXPIRY_DELTA_BLOCKS` | `2` | Yes (env/config for testnet tuning) |
+| Fallback if ZIP-317 fails | `10_000` zats | Keep as last resort only |
+
+Open from parent RFC §7: fixed 4× vs configurable multiplier; exact expiry delta on testnet.
+
+---
+
+## 8. Testing checklist (A1)
+
+- [ ] **Unit:** ZIP-317 fee matches expected zats for 1-in / 2-out Orchard-shaped tx  
+- [ ] **Unit:** priority = 4 × standard  
+- [ ] **Testnet:** send with `priority=false` confirms; fee on-chain plausible  
+- [ ] **Testnet:** send with `priority=true` confirms faster (manual observation)  
+- [ ] **Testnet:** tx with 2-block expiry: after 3+ blocks unmined → `Expired`, balance spendable again  
+- [ ] **Testnet:** speed-up produces **different** txid; original marked `Expired`  
+- [ ] **Regression:** desktop review fee matches tx actually broadcast  
+- [ ] **Regression:** extension no longer relies on `estimatefee` for preflight  
+
+---
+
+## 9. Out of scope for A1 (explicit)
+
+- Zeaking `fee_policy` / observatory / compact expiry detection  
+- Forum post / public announcement  
+- Changing Zebra or lightwalletd  
+- Multi-note spend parity in `orchard_tx` (separate track; needed for reliable speed-up — parent RFC §6)  
+- Phase B standard-fee swap from Shielded Labs  
+
+---
+
+## 10. Decisions log (fill in after review)
+
+| Question | Decision | Date |
+|----------|----------|------|
+| Start A1 in nozy without Zeaking? | **Yes** — Zeaking waits for SL | |
+| Expiry delta for testnet first pass | | |
+| Priority multiplier fixed at 4? | | |
+| Ship speed-up in same PR series as expiry? | | |
+| Metrics opt-in default on/off? | | |
+
+---
+
+## 11. Related docs
+
+| Document | Role |
+|----------|------|
+| [DYNAMIC_FEE_PILOT_PLAN.md](DYNAMIC_FEE_PILOT_PLAN.md) | Full architecture, monitoring, Shielded Labs alignment |
+| [README.md](README.md) | RFC index |
+| [AGENTS.md](../../AGENTS.md) | Contribution gate for behavior-changing work |
+
+---
+
+*When you are ready to implement, start with §4 step 1 (`fee_policy`) on a feature branch; open a GitHub issue linking this doc and the parent RFC per AGENTS.md.*

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -1,0 +1,14 @@
+# RFCs (design proposals)
+
+| Document | Summary |
+|----------|---------|
+| [DYNAMIC_FEE_PILOT_PLAN.md](DYNAMIC_FEE_PILOT_PLAN.md) | Shielded Labs dynamic-fee pilot — architecture (Zebrad-only, ZIP-317, 2-block expiry, speed-up) |
+| [DYNAMIC_FEE_PHASE_A_IMPLEMENTATION.md](DYNAMIC_FEE_PHASE_A_IMPLEMENTATION.md) | **Phase A checklist** — A1 nozy/surfaces now; A2 Zeaking after SL go-ahead |
+| [MULTICHAIN_PRIVACY_CHAINS_RFC.md](MULTICHAIN_PRIVACY_CHAINS_RFC.md) | Namada + Penumbra integration goals, custody, threat model, and design checklists |
+| [NEAR_AND_SECRET_SUPPORT_PLAN.md](NEAR_AND_SECRET_SUPPORT_PLAN.md) | **§11 one plan** (Secret+NEAR+agents order), §5 phases, §9 AI, §10 tag-team |
+| [DEPENDENCY_SPIKE_NOTES.md](DEPENDENCY_SPIKE_NOTES.md) | Cargo spike procedure; temp-crate `core2` yank vs **this repo’s `Cargo.lock`**; re-spike in-tree |
+| [GITHUB_ISSUE_DRAFT_MULTICHAIN_SCOPE.md](GITHUB_ISSUE_DRAFT_MULTICHAIN_SCOPE.md) | Paste-ready GitHub issue for maintainer alignment ([AGENTS.md](../../AGENTS.md)) |
+| [NEXT_STEPS.md](NEXT_STEPS.md) | Checklist from RFC approval → Penumbra smoke test → Namada spike branch |
+| [EXTENSION_PENUMBRA_PORTS.md](EXTENSION_PENUMBRA_PORTS.md) | Localhost **port grid** template (Zebra, LWD, api-server, `pclientd`, Namada) |
+
+These documents are **research and planning only**; they do not change wallet behavior.

--- a/landing/package-lock.json
+++ b/landing/package-lock.json
@@ -2223,6 +2223,16 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.16",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.16.tgz",
@@ -2234,6 +2244,19 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/browserslist": {
@@ -3507,29 +3530,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/minimatch/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
     "node_modules/minimist": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
@@ -3835,26 +3835,10 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/react-router-dom": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.14.0.tgz",
-      "integrity": "sha512-2G3ajSVSZMEtmTjIklRWlNvo8wICEpLihfD/0YMDxbWK2UyP5EGfnoIn9AIQGnF3G/FX0MRbHXdFcD+rL1ZreQ==",
-      "license": "MIT",
-      "dependencies": {
-        "react-router": "7.14.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
-      }
-    },
-    "node_modules/react-router-dom/node_modules/react-router": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.14.0.tgz",
-      "integrity": "sha512-m/xR9N4LQLmAS0ZhkY2nkPA1N7gQ5TUVa5n8TgANuDTARbn1gt+zLPXEm7W0XDTbrQ2AJSJKhoa6yx1D8BcpxQ==",
+    "node_modules/react-router": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.16.0.tgz",
+      "integrity": "sha512-wArC8lVyJb3+jM9OpDyW6hLCizACWkvQR/sSGqSs+o5uEXEtGlqdZ4v8hENR3Jad6i+LRkK93q/+bQAcvl6V1A==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -3871,6 +3855,22 @@
         "react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.16.0.tgz",
+      "integrity": "sha512-kMUAbimWB5FVbF4Bce4bJsiKJWLIUHq/mEG8+CFDnCSgltptBiG5nguducmsJeGKytlCvQud9Qhzpn49iduTlA==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.16.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     },
     "node_modules/require-from-string": {

--- a/src/bin/send_zec.rs
+++ b/src/bin/send_zec.rs
@@ -98,7 +98,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let amount_zatoshis = (amount * 100_000_000.0) as u64;
 
     println!("💸 Estimating transaction fee...");
-    let fee_zatoshis = nozy::cli_helpers::estimate_transaction_fee(&zebra_client).await;
+    let pilot = nozy::PilotSendOptions::default();
+    let fee_zatoshis = nozy::cli_helpers::estimate_transaction_fee_for_send(
+        &zebra_client,
+        memo_bytes_opt.as_deref(),
+        pilot.priority,
+    )
+    .await;
 
     println!("🔧 Building transaction...");
     let transaction = transaction_builder
@@ -109,6 +115,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             amount_zatoshis,
             fee_zatoshis,
             memo_bytes_opt.as_deref(),
+            pilot,
         )
         .await?;
 

--- a/src/cli_helpers.rs
+++ b/src/cli_helpers.rs
@@ -1,56 +1,30 @@
 use crate::error::{NozyError, NozyResult};
+use crate::fee_policy::{estimate_orchard_send_fee_zatoshis, PilotSendOptions};
 use crate::{load_config, HDWallet, NoteScanner, WalletStorage, ZebraClient};
 use dialoguer::Password;
 
+/// ZIP-317 client-side fee for an Orchard send (Zebrad does not implement `estimatefee`).
+pub async fn estimate_transaction_fee_for_send(
+    _zebra_client: &ZebraClient,
+    memo: Option<&[u8]>,
+    priority: bool,
+) -> u64 {
+    let fee_zatoshis = estimate_orchard_send_fee_zatoshis(memo, priority);
+    let label = if priority {
+        "priority (×4)"
+    } else {
+        "standard"
+    };
+    println!(
+        "💰 Estimated fee ({label}): {:.8} ZEC ({fee_zatoshis} zats, ZIP-317)",
+        fee_zatoshis as f64 / 100_000_000.0,
+    );
+    fee_zatoshis
+}
+
+/// Back-compat: standard (non-priority) ZIP-317 estimate.
 pub async fn estimate_transaction_fee(zebra_client: &ZebraClient) -> u64 {
-    const DEFAULT_FEE_ZATOSHIS: u64 = 10_000;
-
-    match zebra_client.get_fee_estimate().await {
-        Ok(estimate) => {
-            if let Some(fee_value) = estimate.get("fee") {
-                if let Some(fee_f64) = fee_value.as_f64() {
-                    let fee_zatoshis = (fee_f64 * 100_000_000.0) as u64;
-                    if fee_zatoshis > 0 {
-                        println!("💰 Estimated fee: {:.8} ZEC ({})", fee_f64, fee_zatoshis);
-                        return fee_zatoshis;
-                    }
-                } else if let Some(fee_u64) = fee_value.as_u64() {
-                    println!(
-                        "💰 Estimated fee: {:.8} ZEC ({})",
-                        fee_u64 as f64 / 100_000_000.0,
-                        fee_u64
-                    );
-                    return fee_u64;
-                }
-            }
-
-            for field in &["feerate", "feeRate", "fee_rate"] {
-                if let Some(fee_value) = estimate.get(*field) {
-                    if let Some(fee_f64) = fee_value.as_f64() {
-                        let fee_zatoshis = (fee_f64 * 100_000_000.0) as u64;
-                        if fee_zatoshis > 0 {
-                            println!("💰 Estimated fee: {:.8} ZEC ({})", fee_f64, fee_zatoshis);
-                            return fee_zatoshis;
-                        }
-                    }
-                }
-            }
-
-            println!(
-                "⚠️  Could not parse fee estimate, using default: {:.8} ZEC",
-                DEFAULT_FEE_ZATOSHIS as f64 / 100_000_000.0
-            );
-            DEFAULT_FEE_ZATOSHIS
-        }
-        Err(e) => {
-            println!(
-                "⚠️  Fee estimation failed: {}, using default: {:.8} ZEC",
-                e,
-                DEFAULT_FEE_ZATOSHIS as f64 / 100_000_000.0
-            );
-            DEFAULT_FEE_ZATOSHIS
-        }
-    }
+    estimate_transaction_fee_for_send(zebra_client, None, false).await
 }
 
 pub async fn load_wallet() -> NozyResult<(HDWallet, WalletStorage)> {
@@ -118,11 +92,12 @@ pub async fn build_and_broadcast_transaction(
     memo: Option<&[u8]>,
     enable_broadcast: bool,
     zebra_url: &str,
+    pilot: PilotSendOptions,
 ) -> NozyResult<String> {
     let fee_zatoshis = if let Some(fee) = fee_zatoshis {
         fee
     } else {
-        estimate_transaction_fee(zebra_client).await
+        estimate_transaction_fee_for_send(zebra_client, memo, pilot.priority).await
     };
     use crate::transaction_history::{SentTransactionRecord, SentTransactionStorage};
     use crate::ZcashTransactionBuilder;
@@ -134,6 +109,9 @@ pub async fn build_and_broadcast_transaction(
         tx_builder.enable_mainnet_broadcast();
     }
 
+    let tip_height = zebra_client.get_best_block_height().await?;
+    let expiry_height = tip_height.saturating_add(pilot.expiry_delta_blocks);
+
     let transaction = tx_builder
         .build_send_transaction(
             zebra_client,
@@ -142,6 +120,7 @@ pub async fn build_and_broadcast_transaction(
             amount_zatoshis,
             fee_zatoshis,
             memo,
+            pilot,
         )
         .await?;
 
@@ -165,13 +144,15 @@ pub async fn build_and_broadcast_transaction(
                     .map(|note| hex::encode(note.orchard_note.nullifier.to_bytes()))
                     .collect();
 
-                let mut tx_record = SentTransactionRecord::new(
+                let mut tx_record = SentTransactionRecord::new_pilot(
                     network_txid.clone(),
                     recipient.to_string(),
                     amount_zatoshis,
                     fee_zatoshis,
                     memo.map(|m| m.to_vec()),
                     spent_note_ids,
+                    pilot.priority,
+                    expiry_height,
                 );
                 tx_record.mark_broadcast();
                 tx_storage.save_transaction(tx_record)?;

--- a/src/fee_policy.rs
+++ b/src/fee_policy.rs
@@ -1,0 +1,142 @@
+//! Client-side ZIP-317 fee policy for Orchard sends (Zebrad has no `estimatefee`).
+//!
+//! Interim home until Shielded Labs approves moving shared logic into `zeaking`.
+
+/// ZIP-317 marginal fee per logical action (zatoshis).
+pub const MARGINAL_FEE_ZATOSHIS: u64 = 5_000;
+/// ZIP-317 grace logical actions (minimum billable action count).
+pub const GRACE_ACTIONS: u32 = 2;
+/// Pilot priority multiplier when the user opts in.
+pub const PRIORITY_MULTIPLIER: u64 = 4;
+/// Default transaction expiry delta (~2 minutes at 75s/block).
+pub const PILOT_EXPIRY_DELTA_BLOCKS: u32 = 2;
+/// Last-resort fee if shape computation overflows (should not happen in practice).
+pub const FALLBACK_FEE_ZATOSHIS: u64 = 10_000;
+
+/// User-visible send options for the dynamic-fee pilot (Phase A1).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PilotSendOptions {
+    /// When true, fee is [`conventional_fee_zatoshis`] × [`PRIORITY_MULTIPLIER`].
+    pub priority: bool,
+    /// Blocks after chain tip at build time when the tx expires (`expiry_height = tip + delta`).
+    pub expiry_delta_blocks: u32,
+}
+
+impl Default for PilotSendOptions {
+    fn default() -> Self {
+        Self {
+            priority: false,
+            expiry_delta_blocks: PILOT_EXPIRY_DELTA_BLOCKS,
+        }
+    }
+}
+
+/// ZIP-317 inputs for a typical Orchard-only shielded send built by `orchard_tx`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct OrchardSendFeeShape {
+    /// Orchard bundle actions (spend + outputs).
+    pub orchard_actions: u32,
+    /// Non-empty memo byte length on the recipient output (0 if none).
+    pub memo_len: usize,
+}
+
+impl OrchardSendFeeShape {
+    /// Shape for `build_single_spend`: one spend, one recipient output, optional change output.
+    pub fn single_spend_send(has_change: bool, memo: Option<&[u8]>) -> Self {
+        let outputs = if has_change { 2 } else { 1 };
+        Self {
+            orchard_actions: 1 + outputs,
+            memo_len: memo.map(|m| m.len()).unwrap_or(0),
+        }
+    }
+
+    /// Conservative preview shape when note values are not yet known (assumes change output).
+    pub fn estimate_preview(memo: Option<&[u8]>) -> Self {
+        Self::single_spend_send(true, memo)
+    }
+}
+
+/// ZIP-317 logical actions for an Orchard-only transaction shape.
+pub fn logical_actions(shape: &OrchardSendFeeShape) -> u32 {
+    let memo_chunks = if shape.memo_len == 0 {
+        0
+    } else {
+        div_ceil(shape.memo_len, 512) as u32
+    };
+    // Orchard outputs exist → 2 free memo chunks (ZIP-317).
+    let free_memo = if shape.orchard_actions > 0 { 2 } else { 0 };
+    let memo_contribution = memo_chunks.saturating_sub(free_memo);
+    shape.orchard_actions.saturating_add(memo_contribution)
+}
+
+/// ZIP-317 conventional fee in zatoshis: `marginal_fee × max(grace_actions, logical_actions)`.
+pub fn conventional_fee_zatoshis(shape: &OrchardSendFeeShape) -> u64 {
+    let actions = logical_actions(shape);
+    let billable = actions.max(GRACE_ACTIONS) as u64;
+    MARGINAL_FEE_ZATOSHIS
+        .saturating_mul(billable)
+        .max(MARGINAL_FEE_ZATOSHIS.saturating_mul(GRACE_ACTIONS as u64))
+}
+
+/// Final fee for a send, optionally multiplied for pilot priority.
+pub fn fee_zatoshis(shape: &OrchardSendFeeShape, priority: bool) -> u64 {
+    let base = conventional_fee_zatoshis(shape);
+    if priority {
+        base.saturating_mul(PRIORITY_MULTIPLIER)
+    } else {
+        base
+    }
+}
+
+/// Fee estimate for UI / CLI preview (assumes change output exists).
+pub fn estimate_orchard_send_fee_zatoshis(memo: Option<&[u8]>, priority: bool) -> u64 {
+    let shape = OrchardSendFeeShape::estimate_preview(memo);
+    let fee = fee_zatoshis(&shape, priority);
+    if fee == 0 {
+        FALLBACK_FEE_ZATOSHIS
+    } else {
+        fee
+    }
+}
+
+fn div_ceil(a: usize, b: usize) -> usize {
+    if b == 0 {
+        return a;
+    }
+    a.saturating_add(b - 1) / b
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn grace_minimum_fee_is_10000_zats() {
+        let shape = OrchardSendFeeShape {
+            orchard_actions: 1,
+            memo_len: 0,
+        };
+        assert_eq!(conventional_fee_zatoshis(&shape), 10_000);
+    }
+
+    #[test]
+    fn typical_three_action_send_is_15000_zats() {
+        let shape = OrchardSendFeeShape::single_spend_send(true, None);
+        assert_eq!(shape.orchard_actions, 3);
+        assert_eq!(conventional_fee_zatoshis(&shape), 15_000);
+    }
+
+    #[test]
+    fn priority_multiplies_by_four() {
+        let shape = OrchardSendFeeShape::estimate_preview(None);
+        assert_eq!(fee_zatoshis(&shape, false), 15_000);
+        assert_eq!(fee_zatoshis(&shape, true), 60_000);
+    }
+
+    #[test]
+    fn memo_adds_logical_actions_beyond_free_chunks() {
+        let shape = OrchardSendFeeShape::single_spend_send(true, Some(&[0u8; 1200]));
+        assert!(logical_actions(&shape) > 3);
+        assert!(conventional_fee_zatoshis(&shape) > 15_000);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,8 @@ pub mod cli_helpers;
 #[cfg(feature = "native")]
 pub mod config;
 #[cfg(feature = "native")]
+pub mod fee_policy;
+#[cfg(feature = "native")]
 pub mod grpc_client;
 #[cfg(feature = "native")]
 pub mod local_analytics;
@@ -109,11 +111,18 @@ pub use bridge::{
     StoredSwap, SwapStorage,
 };
 #[cfg(feature = "native")]
-pub use cli_helpers::{estimate_transaction_fee, scan_notes_for_sending};
+pub use cli_helpers::{
+    estimate_transaction_fee, estimate_transaction_fee_for_send, scan_notes_for_sending,
+};
 #[cfg(feature = "native")]
 pub use config::{load_config, save_config, update_last_scan_height, WalletConfig};
 #[cfg(feature = "native")]
 pub use config::{BackendKind, Protocol};
+#[cfg(feature = "native")]
+pub use fee_policy::{
+    estimate_orchard_send_fee_zatoshis, OrchardSendFeeShape, PilotSendOptions,
+    PILOT_EXPIRY_DELTA_BLOCKS, PRIORITY_MULTIPLIER,
+};
 #[cfg(feature = "native")]
 pub use monero::{
     MoneroRpcClient, MoneroTransactionRecord, MoneroTransactionStatus, MoneroTransactionStorage,

--- a/src/main.rs
+++ b/src/main.rs
@@ -114,6 +114,11 @@ pub enum Commands {
         // No short flag: global `--mainnet` already uses `-m`.
         #[arg(long, help = "Optional memo message (max 512 characters)")]
         memo: Option<String>,
+        #[arg(
+            long,
+            help = "Pay priority fee (ZIP-317 standard fee × 4; opt-in pilot)"
+        )]
+        priority: bool,
     },
 
     #[command(about = "Display wallet information including addresses and network")]
@@ -562,7 +567,14 @@ async fn execute_command(_command: Commands, mut config: nozy::WalletConfig) -> 
             } else {
                 None
             };
-            let scan_start = effective_start.unwrap_or(3_050_000);
+            // Mainnet: Orchard-heavy range default. Testnet: chain height / resets differ — start from
+            // genesis unless user set last_scan or --start-height (first chunk is still capped below).
+            let default_first_scan_start: u32 = if config.network == "testnet" {
+                1
+            } else {
+                3_050_000
+            };
+            let scan_start = effective_start.unwrap_or(default_first_scan_start);
             let chain_tip = zebra_client.get_block_count().await?;
             let requested_end = if let Some(end) = end_height {
                 end.max(scan_start)
@@ -687,6 +699,7 @@ async fn execute_command(_command: Commands, mut config: nozy::WalletConfig) -> 
             amount,
             zebra_url,
             memo,
+            priority,
         } => {
             if let Some(url) = zebra_url {
                 config.zebra_url = url;
@@ -773,7 +786,16 @@ async fn execute_command(_command: Commands, mut config: nozy::WalletConfig) -> 
             );
 
             println!("\n💸 Estimating transaction fee...");
-            let fee_zatoshis = nozy::cli_helpers::estimate_transaction_fee(&zebra_client).await;
+            let memo_preview = memo
+                .as_deref()
+                .map(|m| m.trim().as_bytes())
+                .filter(|b| !b.is_empty());
+            let fee_zatoshis = nozy::cli_helpers::estimate_transaction_fee_for_send(
+                &zebra_client,
+                memo_preview,
+                priority,
+            )
+            .await;
             let total_amount = amount_zatoshis + fee_zatoshis;
             println!(
                 "  Fee:       {:.8} ZEC",
@@ -941,6 +963,10 @@ async fn execute_command(_command: Commands, mut config: nozy::WalletConfig) -> 
 
             println!("Processing...");
 
+            let pilot = nozy::PilotSendOptions {
+                priority,
+                expiry_delta_blocks: nozy::PILOT_EXPIRY_DELTA_BLOCKS,
+            };
             match build_and_broadcast_transaction(
                 &zebra_client,
                 &spendable_notes,
@@ -950,6 +976,7 @@ async fn execute_command(_command: Commands, mut config: nozy::WalletConfig) -> 
                 memo_bytes_opt.as_deref(),
                 enable_broadcast,
                 &config.zebra_url,
+                pilot,
             )
             .await
             {

--- a/src/orchard_tx.rs
+++ b/src/orchard_tx.rs
@@ -18,7 +18,6 @@ use orchard::{
 use rand::rngs::OsRng;
 use std::sync::{Arc, OnceLock};
 use zcash_address::unified::{Container, Encoding};
-use zcash_primitives::transaction::builder::DEFAULT_TX_EXPIRY_DELTA;
 use zcash_primitives::transaction::sighash::{signature_hash, SignableInput};
 use zcash_primitives::transaction::txid::TxIdDigester;
 use zcash_primitives::transaction::{Authorized, TransactionData, TxVersion, Unauthorized};
@@ -155,6 +154,7 @@ impl OrchardTransactionBuilder {
         amount_zatoshis: u64,
         fee_zatoshis: u64,
         memo: Option<&[u8]>,
+        expiry_delta_blocks: u32,
     ) -> NozyResult<OrchardBuiltSpend> {
         println!("Building Orchard transaction...");
 
@@ -309,7 +309,7 @@ impl OrchardTransactionBuilder {
             }
         };
         let expiry_height =
-            BlockHeight::from_u32(tx_build_height.saturating_add(DEFAULT_TX_EXPIRY_DELTA));
+            BlockHeight::from_u32(tx_build_height.saturating_add(expiry_delta_blocks));
         let unauthorized_zat = unauthorized.clone().try_map_value_balance(|vb| {
             ZatBalance::from_i64(vb).map_err(|e| {
                 NozyError::InvalidOperation(format!(

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -163,6 +163,7 @@ mod tests {
                 1000,
                 100,
                 None,
+                crate::PILOT_EXPIRY_DELTA_BLOCKS,
             )
             .await;
         assert!(result.is_err() || result.is_ok());

--- a/src/transaction_builder.rs
+++ b/src/transaction_builder.rs
@@ -1,4 +1,5 @@
 use crate::error::{NozyError, NozyResult};
+use crate::fee_policy::{OrchardSendFeeShape, PilotSendOptions};
 use crate::notes::SpendableNote;
 use crate::orchard_tx::{OrchardTransactionBuilder, ZebraJsonRpcOrchardWitnessProvider};
 use crate::zebra_integration::ZebraClient;
@@ -42,6 +43,7 @@ impl ZcashTransactionBuilder {
         amount_zatoshis: u64,
         fee_zatoshis: u64,
         memo: Option<&[u8]>,
+        pilot: PilotSendOptions,
     ) -> NozyResult<SignedTransaction> {
         use crate::privacy::validate_shielded_address;
         validate_shielded_address(recipient_address)?;
@@ -80,6 +82,16 @@ impl ZcashTransactionBuilder {
             )));
         }
 
+        let has_change = total_available > amount_zatoshis.saturating_add(fee_zatoshis);
+        let shape = OrchardSendFeeShape::single_spend_send(has_change, memo);
+        let expected_fee = crate::fee_policy::fee_zatoshis(&shape, pilot.priority);
+        if fee_zatoshis < expected_fee {
+            return Err(NozyError::InvalidOperation(format!(
+                "Fee {} zats is below ZIP-317 minimum {} zats for this transaction shape",
+                fee_zatoshis, expected_fee
+            )));
+        }
+
         let orchard_builder = OrchardTransactionBuilder::new(true);
         let built = orchard_builder
             .build_single_spend(
@@ -90,6 +102,7 @@ impl ZcashTransactionBuilder {
                 amount_zatoshis,
                 fee_zatoshis,
                 memo,
+                pilot.expiry_delta_blocks,
             )
             .await?;
 

--- a/src/transaction_history.rs
+++ b/src/transaction_history.rs
@@ -40,6 +40,14 @@ pub struct SentTransactionRecord {
     pub confirmations: u32,
 
     pub spent_note_ids: Vec<String>,
+
+    /// Dynamic-fee pilot: user opted into priority (fee ×4).
+    #[serde(default)]
+    pub priority: bool,
+
+    /// Absolute chain height after which the tx must not be mined (pilot: tip + 2).
+    #[serde(default)]
+    pub expiry_height: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -89,6 +97,9 @@ pub enum TransactionStatus {
     Confirmed,
 
     Failed,
+
+    /// Broadcast but never mined before [`SentTransactionRecord::expiry_height`].
+    Expired,
 }
 
 impl TransactionStatus {
@@ -98,6 +109,10 @@ impl TransactionStatus {
 
     pub fn is_pending(&self) -> bool {
         matches!(self, TransactionStatus::Pending)
+    }
+
+    pub fn is_expired(&self) -> bool {
+        matches!(self, TransactionStatus::Expired)
     }
 }
 
@@ -134,6 +149,36 @@ impl SentTransactionRecord {
             block_time: None,
             confirmations: 0,
             spent_note_ids,
+            priority: false,
+            expiry_height: None,
+        }
+    }
+
+    pub fn new_pilot(
+        txid: String,
+        recipient_address: String,
+        amount_zatoshis: u64,
+        fee_zatoshis: u64,
+        memo: Option<Vec<u8>>,
+        spent_note_ids: Vec<String>,
+        priority: bool,
+        expiry_height: u32,
+    ) -> Self {
+        Self {
+            txid,
+            recipient_address,
+            amount_zatoshis,
+            fee_zatoshis,
+            memo,
+            created_at: Utc::now(),
+            broadcast_at: None,
+            status: TransactionStatus::Pending,
+            block_height: None,
+            block_time: None,
+            confirmations: 0,
+            spent_note_ids,
+            priority,
+            expiry_height: Some(expiry_height),
         }
     }
 
@@ -155,6 +200,11 @@ impl SentTransactionRecord {
 
     pub fn mark_failed(&mut self) {
         self.status = TransactionStatus::Failed;
+    }
+
+    pub fn mark_expired(&mut self) {
+        self.status = TransactionStatus::Expired;
+        self.confirmations = 0;
     }
 }
 

--- a/src/version_info.rs
+++ b/src/version_info.rs
@@ -10,4 +10,4 @@ macro_rules! set_release_codename {
     };
 }
 
-set_release_codename!("Hot Lemon Pepper");
+set_release_codename!("Priority Lane");

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -200,6 +200,7 @@ async fn test_end_to_end_flow_create_scan_send() {
             amount_zatoshis,
             fee_zatoshis,
             Some(b"Integration test transaction"),
+            nozy::PILOT_EXPIRY_DELTA_BLOCKS,
         )
         .await
         .expect("Failed to build transaction");
@@ -281,6 +282,7 @@ async fn test_transaction_building() {
             10_000,
             10_000,
             None,
+            nozy::PILOT_EXPIRY_DELTA_BLOCKS,
         )
         .await;
 


### PR DESCRIPTION
## Summary

Phase A1 dynamic-fee pilot — **single commit** on this branch (Zeaking Phase 2 moved to `feat/zeaking-phase2-sync-to-tip`).

- `src/fee_policy.rs` — ZIP-317 conventional fee, opt-in priority ×4, 2-block expiry
- CLI `send --priority`, api-server + desktop send/fee estimate
- v2.3.0 release prep (changelog, README, version bump) in latest commit

## Scope

**In:** nozy core + native surfaces (CLI, api-server, desktop Tauri)  
**Out:** Zeaking crate, extension WASM fees, expiry polling, speed-up rebuild

## Test plan

- [x] `cargo test fee_policy`
- [x] CI green on this branch
- [x] Testnet: `nozy send ...` and `nozy send ... --priority`
- [ ] Mainnet pilot only after review

## After merge

Tag `v2.3.0` per `docs/RELEASE_v2.3.0_CLI.md`.

## Related

Zeaking + extension scan tab: PR from `feat/zeaking-phase2-sync-to-tip` (popup-quality fix pushed).