### PR TITLE
fix(desktop): expose transaction status in history API and UI

### DIFF
--- a/desktop-client/README.md
+++ b/desktop-client/README.md
@@ -137,8 +137,8 @@ All commands are exposed to the frontend via Tauri's invoke system.
 ### Transactions
 - `send_transaction(recipient, amount, memo?, zebra_url?, password?)` - Send ZEC
 - `estimate_fee(zebra_url?)` - Estimate transaction fee
-- `get_transaction_history()` - Get transaction history
-- `get_transaction(txid)` - Get specific transaction
+- `get_transaction_history()` - Local sent txs (`status`, `confirmations`, `block_height`, etc.)
+- `get_transaction(txid)` - Same fields for one tx
 
 ### Configuration
 - `get_config()` - Get configuration

--- a/desktop-client/src-tauri/src/commands/transaction.rs
+++ b/desktop-client/src-tauri/src/commands/transaction.rs
@@ -1,11 +1,44 @@
 use crate::error::TauriError;
 use nozy::{
     estimate_transaction_fee, load_config, scan_notes_for_sending,
-    transaction_history::{SentTransactionRecord, SentTransactionStorage},
+    transaction_history::{
+        SentTransactionRecord, SentTransactionStorage, TransactionStatus,
+    },
     WalletStorage, ZcashTransactionBuilder, ZebraClient,
 };
 use serde::{Deserialize, Serialize};
 use tauri::command;
+
+fn status_key(status: &TransactionStatus) -> &'static str {
+    match status {
+        TransactionStatus::Pending => "pending",
+        TransactionStatus::Confirmed => "confirmed",
+        TransactionStatus::Failed => "failed",
+    }
+}
+
+fn tx_record_json(tx: &SentTransactionRecord) -> serde_json::Value {
+    serde_json::json!({
+        "txid": tx.txid,
+        "recipient_address": tx.recipient_address,
+        "recipient": tx.recipient_address,
+        "amount_zatoshis": tx.amount_zatoshis,
+        "amount_zec": tx.amount_zatoshis as f64 / 100_000_000.0,
+        "fee_zatoshis": tx.fee_zatoshis,
+        "fee_zec": tx.fee_zatoshis as f64 / 100_000_000.0,
+        "memo": tx.memo.as_ref().and_then(|m| String::from_utf8(m.clone()).ok()),
+        "status": status_key(&tx.status),
+        "transaction_type": "sent",
+        "type": "sent",
+        "block_height": tx.block_height,
+        "confirmations": tx.confirmations,
+        "broadcast_at": tx.broadcast_at.map(|d| d.to_rfc3339()),
+        "created_at": tx.created_at.to_rfc3339(),
+        "timestamp": tx.created_at.timestamp(),
+        "broadcast": tx.broadcast_at.is_some(),
+        "spent_note_ids": tx.spent_note_ids,
+    })
+}
 
 #[derive(Debug, Serialize)]
 pub struct SendTransactionResponse {
@@ -155,18 +188,7 @@ pub async fn get_transaction_history() -> Result<Vec<serde_json::Value>, TauriEr
 
     let json_transactions: Vec<serde_json::Value> = transactions
         .iter()
-        .map(|tx| {
-            serde_json::json!({
-                "txid": tx.txid.clone(),
-                "recipient": tx.recipient_address.clone(),
-                "amount_zec": tx.amount_zatoshis as f64 / 100_000_000.0,
-                "fee_zec": tx.fee_zatoshis as f64 / 100_000_000.0,
-                "memo": tx.memo.as_ref().and_then(|m| String::from_utf8(m.clone()).ok()),
-                "broadcast": tx.broadcast_at.is_some(),
-                "confirmations": tx.confirmations,
-                "timestamp": tx.created_at.timestamp(),
-            })
-        })
+        .map(tx_record_json)
         .collect();
 
     Ok(json_transactions)
@@ -185,15 +207,5 @@ pub async fn get_transaction(txid: String) -> Result<serde_json::Value, TauriErr
             code: Some("TRANSACTION_NOT_FOUND".to_string()),
         })?;
 
-    Ok(serde_json::json!({
-        "txid": transaction.txid.clone(),
-        "recipient": transaction.recipient_address.clone(),
-        "amount_zec": transaction.amount_zatoshis as f64 / 100_000_000.0,
-        "fee_zec": transaction.fee_zatoshis as f64 / 100_000_000.0,
-        "memo": transaction.memo.as_ref().and_then(|m| String::from_utf8(m.clone()).ok()),
-        "broadcast": transaction.broadcast_at.is_some(),
-        "confirmations": transaction.confirmations,
-        "timestamp": transaction.created_at.timestamp(),
-        "spent_notes": transaction.spent_note_ids.clone(),
-    }))
+    Ok(tx_record_json(&transaction))
 }

--- a/desktop-client/src/lib/api.ts
+++ b/desktop-client/src/lib/api.ts
@@ -93,7 +93,7 @@ export const walletApi = {
   },
 
   estimateFee: async (zebraUrl?: string): Promise<{ data: number }> => {
-    const result = await invoke<number>("estimate_fee", { zebraUrl });
+    const result = await invoke<number>("estimate_fee", { zebra_url: zebraUrl });
     return { data: result };
   },
 

--- a/desktop-client/src/pages/History.tsx
+++ b/desktop-client/src/pages/History.tsx
@@ -26,9 +26,15 @@ function normalizeTx(raw: any): HistoryTx {
     ? raw.amount_zec
     : (raw.amount_zatoshis != null ? raw.amount_zatoshis / 100_000_000 : 0);
   const recipient = raw.recipient_address ?? raw.recipient ?? "";
-  const status = raw.status != null
+  const statusRaw = raw.status != null
     ? String(raw.status).toLowerCase().replace(/\s/g, "_")
     : "unknown";
+  const status =
+    statusRaw === "confirmed" ||
+    statusRaw === "pending" ||
+    statusRaw === "failed"
+      ? statusRaw
+      : statusRaw;
   const dateRaw = raw.broadcast_at ?? raw.created_at ?? raw.date ?? raw.block_time;
   const date =
     typeof dateRaw === "string"
@@ -47,13 +53,13 @@ function normalizeTx(raw: any): HistoryTx {
     amount: amountZec,
     date,
     address: recipient || (txid ? `${txid.slice(0, 8)}...${txid.slice(-4)}` : "—"),
-    status: status === "confirmed" ? "confirmed" : status === "pending" ? "pending" : status,
+    status,
     memo,
   };
 }
 
 type FilterType = "all" | "sent" | "received";
-type FilterStatus = "all" | "confirmed" | "pending";
+type FilterStatus = "all" | "confirmed" | "pending" | "failed";
 type FilterDateRange = "all" | "7" | "30" | "90";
 
 function filterAndSortTxs(
@@ -305,6 +311,7 @@ export function HistoryPage() {
               <option value="all">All statuses</option>
               <option value="confirmed">Confirmed</option>
               <option value="pending">Pending</option>
+              <option value="failed">Failed</option>
             </select>
             <select
               value={filterDateRange}
@@ -422,12 +429,14 @@ export function HistoryPage() {
                     )}
                   </p>
                   <span
-                    className={`text-xs px-2 py-0.5 rounded-full ${
+                    className={`text-xs px-2 py-0.5 rounded-full capitalize ${
                       tx.status === "confirmed"
                         ? "bg-green-100 text-green-700"
                         : tx.status === "pending"
                           ? "bg-yellow-100 text-yellow-700"
-                          : "bg-gray-100 text-gray-700"
+                          : tx.status === "failed"
+                            ? "bg-red-100 text-red-700"
+                            : "bg-gray-100 text-gray-700"
                     }`}
                   >
                     {tx.status}


### PR DESCRIPTION
Tauri get_transaction_history and get_transaction now return status, block height, and broadcast timestamps so the History page no longer shows every send as unknown. Add a failed status filter and badge styling. Pass zebra_url correctly to estimate_fee.