### PR TITLE
fix(deps): bump librustzcash to the NU6.2 release set for correct con…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1042,6 +1042,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "corez"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4df6f98652d30167eaeea34d77b730e07c8caba6df17bd4551842b9b8da01deb"
+
+[[package]]
 name = "cosmos-sdk-proto"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1505,12 +1511,12 @@ checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "equihash"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca4f333d4ccc9d23c06593733673026efa71a332e028b00f12cf427b9677dce9"
+checksum = "306286e8dcc39ab3dfceb74c792ce8baffdab90591321d3ffaae64829734c37f"
 dependencies = [
  "blake2b_simd",
- "core2",
+ "corez",
 ]
 
 [[package]]
@@ -1923,9 +1929,9 @@ dependencies = [
 
 [[package]]
 name = "halo2_gadgets"
-version = "0.3.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73a5e510d58a07d8ed238a5a8a436fe6c2c79e1bb2611f62688bc65007b4e6e7"
+checksum = "fb2a697cad929f706b7987fe804ad57d43622cd37463ba7e4d662a926fdcfea3"
 dependencies = [
  "arrayvec",
  "bitvec",
@@ -2738,10 +2744,11 @@ dependencies = [
  "zcash_note_encryption",
  "zcash_primitives",
  "zcash_proofs",
- "zcash_protocol",
+ "zcash_protocol 0.9.0",
  "zcash_transparent",
  "zeaking",
  "zeroize",
+ "zip32",
 ]
 
 [[package]]
@@ -2762,7 +2769,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber 0.3.23",
- "zcash_protocol",
+ "zcash_protocol 0.7.2",
  "zeaking",
 ]
 
@@ -2873,14 +2880,14 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orchard"
-version = "0.11.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1ef66fcf99348242a20d582d7434da381a867df8dc155b3a980eca767c56137"
+checksum = "a54f8d29bfb1e76a9d4e868a1a08cce2e57dd2bdc66232982822ad3114b91ab3"
 dependencies = [
  "aes",
  "bitvec",
  "blake2b_simd",
- "core2",
+ "corez",
  "ff 0.13.1",
  "fpe",
  "getset",
@@ -2895,6 +2902,7 @@ dependencies = [
  "nonempty",
  "pasta_curves",
  "rand 0.8.5",
+ "rand_core 0.6.4",
  "reddsa",
  "serde",
  "sinsemilla",
@@ -3770,9 +3778,9 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "sapling-crypto"
-version = "0.5.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d3c081c83f1dc87403d9d71a06f52301c0aa9ea4c17da2a3435bbf493ffba4"
+checksum = "2d70756ede56b5e4dd417979777bd87ddb83dfcbd0815dbf8175a9920537f8a0"
 dependencies = [
  "aes",
  "bellman",
@@ -3780,7 +3788,7 @@ dependencies = [
  "blake2b_simd",
  "blake2s_simd",
  "bls12_381",
- "core2",
+ "corez",
  "document-features",
  "ff 0.13.1",
  "fpe",
@@ -5672,25 +5680,26 @@ dependencies = [
 
 [[package]]
 name = "zcash_address"
-version = "0.10.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee4491dddd232de02df42481757054dc19c8bc51cf709cfec58feebfef7c3c9a"
+checksum = "58342d0aaa8e2fa98849636f52800ac4bf020574c944c974742fc933db58cac2"
 dependencies = [
  "bech32 0.11.1",
  "bs58 0.5.1",
- "core2",
+ "corez",
  "f4jumble",
  "zcash_encoding",
- "zcash_protocol",
+ "zcash_protocol 0.9.0",
 ]
 
 [[package]]
 name = "zcash_encoding"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bca38087e6524e5f51a5b0fb3fc18f36d7b84bf67b2056f494ca0c281590953d"
+checksum = "1440921903cdb86133fb9e2fe800be488015db2939a30bedb413078a1acb0306"
 dependencies = [
- "core2",
+ "corez",
+ "hex",
  "nonempty",
 ]
 
@@ -5709,51 +5718,39 @@ dependencies = [
 
 [[package]]
 name = "zcash_primitives"
-version = "0.26.4"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fd9ff256fb298a7e94a73c1adad6c7e0b4b194b902e777ee9f5f2e12c4c4776"
+checksum = "c69e07f5eb3f682a6467b4b08ee4956f1acd1e886d70b21c4766953b3a1beba2"
 dependencies = [
- "bip32 0.6.0-pre.1",
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
- "bs58 0.5.1",
- "core2",
+ "corez",
  "crypto-common 0.2.0-rc.1",
  "document-features",
  "equihash",
  "ff 0.13.1",
- "fpe",
- "getset",
- "group 0.13.0",
  "hex",
  "incrementalmerkletree",
  "jubjub",
  "memuse",
  "nonempty",
  "orchard",
- "rand 0.8.5",
  "rand_core 0.6.4",
  "redjubjub",
- "ripemd 0.1.3",
  "sapling-crypto",
  "sha2 0.10.9",
- "subtle",
- "tracing",
- "zcash_address",
  "zcash_encoding",
  "zcash_note_encryption",
- "zcash_protocol",
+ "zcash_protocol 0.9.0",
  "zcash_script",
- "zcash_spec",
  "zcash_transparent",
- "zip32",
 ]
 
 [[package]]
 name = "zcash_proofs"
-version = "0.26.1"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a2c13bb673d542608a0e6502ac5494136e7ce4ce97e92dd239489b2523eed9"
+checksum = "3de6b0ca82e08a9d38b1121f87c5b180b5feac19fecba074cb582882210d2371"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -5761,7 +5758,6 @@ dependencies = [
  "document-features",
  "group 0.13.0",
  "jubjub",
- "lazy_static",
  "rand_core 0.6.4",
  "redjubjub",
  "sapling-crypto",
@@ -5780,6 +5776,19 @@ dependencies = [
  "document-features",
  "hex",
  "memuse",
+]
+
+[[package]]
+name = "zcash_protocol"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bec496a0bd62dae98c4b26f51c5dab112d0c5350bbc2ccfdfd05bb3454f714d"
+dependencies = [
+ "corez",
+ "document-features",
+ "hex",
+ "memuse",
+ "zcash_encoding",
 ]
 
 [[package]]
@@ -5810,14 +5819,13 @@ dependencies = [
 
 [[package]]
 name = "zcash_transparent"
-version = "0.6.4"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cd0a5fdc55d2310e1788d379edf0d68aa735041c18773503366b3c1a6df138b"
+checksum = "15df1908b428d4edeb7c7caae5692e05e2e92e5c38007a40b20ac098efdffd96"
 dependencies = [
  "bip32 0.6.0-pre.1",
- "blake2b_simd",
  "bs58 0.5.1",
- "core2",
+ "corez",
  "document-features",
  "getset",
  "hex",
@@ -5828,7 +5836,7 @@ dependencies = [
  "subtle",
  "zcash_address",
  "zcash_encoding",
- "zcash_protocol",
+ "zcash_protocol 0.9.0",
  "zcash_script",
  "zcash_spec",
  "zip32",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,12 +43,15 @@ bip39 = "2.1"
 
 # Zcash crypto stack -- default-features off to disable multicore on WASM
 # Native builds re-enable multicore via the "native" feature for parallel proving
-# Align with Zebra 4.3.x workspace so proofs/serialization match consensus verification.
-orchard = { version = "0.11", default-features = false, features = ["circuit", "std"] }
-zcash_primitives = { version = "0.26", default-features = false, features = ["std", "circuits"] }
-zcash_protocol = "0.7"
-zcash_address = "0.10"
+# Aligned to the NU6.2 librustzcash release set (matches zebra 0a2b87f5 / zaino dev) so
+# BranchId::for_height returns NU6.2 (5437f330) and proofs/serialization match consensus.
+orchard = { version = "0.14", default-features = false, features = ["circuit", "std"] }
+zcash_primitives = { version = "0.28", default-features = false, features = ["std", "circuits"] }
+zcash_protocol = "0.9"
+zcash_address = "0.12"
 zcash_note_encryption = "0.4.1"
+# zcash_primitives 0.28 dropped its zip32 re-export; depend on the standalone crate.
+zip32 = "0.2.1"
 
 # Serialization for Zcash types
 ark-serialize = "0.4"
@@ -107,8 +110,8 @@ rayon = { version = "1.8", optional = true }
 # Futures utilities
 futures = { version = "0.3", optional = true }
 
-zcash_proofs = { version = "0.26.1", optional = true, default-features = false, features = ["bundled-prover"] }
-zcash_transparent = { version = "0.6.4", optional = true, default-features = false }
+zcash_proofs = { version = "0.28", optional = true, default-features = false, features = ["bundled-prover"] }
+zcash_transparent = { version = "0.8", optional = true, default-features = false }
 
 [features]
 default = ["native"]

--- a/src/hd_wallet.rs
+++ b/src/hd_wallet.rs
@@ -15,7 +15,7 @@ use orchard::{
     Address as OrchardAddress,
 };
 use zcash_address::unified::{Address as UnifiedAddress, Encoding, Receiver};
-use zcash_primitives::zip32::AccountId;
+use zip32::AccountId;
 use zcash_protocol::consensus::NetworkType;
 
 #[derive(Debug, Clone)]
@@ -409,7 +409,7 @@ impl HDWallet {
         let seed_bytes = self.mnemonic.to_seed("").to_vec();
         let secure_seed = SecureSeed::new(seed_bytes);
 
-        let account_id = zcash_primitives::zip32::AccountId::try_from(0)
+        let account_id = zip32::AccountId::try_from(0)
             .map_err(|e| NozyError::KeyDerivation(format!("Invalid account ID: {:?}", e)))?;
 
         let orchard_sk = SpendingKey::from_zip32_seed(secure_seed.as_bytes(), 133, account_id)

--- a/src/key_management.rs
+++ b/src/key_management.rs
@@ -60,7 +60,7 @@ where
     F: FnOnce(&orchard::keys::SpendingKey) -> NozyResult<T>,
 {
     use orchard::keys::SpendingKey;
-    use zcash_primitives::zip32::AccountId;
+    use zip32::AccountId;
 
     let account_id = AccountId::try_from(account_id)
         .map_err(|e| NozyError::KeyDerivation(format!("Invalid account ID: {:?}", e)))?;

--- a/src/notes.rs
+++ b/src/notes.rs
@@ -19,7 +19,7 @@ use orchard::{
     note::{Note, Nullifier},
     Address as OrchardAddress,
 };
-use zcash_primitives::zip32::AccountId;
+use zip32::AccountId;
 
 use zcash_note_encryption::try_compact_note_decryption;
 


### PR DESCRIPTION
Motivation: NU6.2 is active on mainnet. NozyWallet derives the signing branch ID via BranchId::for_height(&MAIN_NETWORK, height), which relies on zcash_primitives knowing the active upgrade. The pinned zcash_primitives 0.26 / zcash_protocol 0.7 predate NU6.2, so for_height returns NU6.1's ID (0x4dec4df0) and a NU6.2 zebrad rejects the tx ("incorrect consensus branch id", code -25).

Change: bump to the NU6.2 release set (orchard 0.14, zcash_primitives 0.28, zcash_protocol 0.9, zcash_address 0.12, zcash_proofs 0.28, zcash_transparent 0.8). 0.28 dropped the zip32 re-export, so add the standalone zip32 crate and repoint zcash_primitives::zip32::AccountId → zip32::AccountId (4 sites). No other code changes.

Test evidence: built --release; a shielded Orchard send to mainnet went from code -25 rejection → accepted + mined (branch ID 0x5437f330).

Maintainer alignment: approved by @Lowo (Signal).
AI disclosure: implemented with Claude Code (Anthropic); dependency bump + import repoint + this text. Human author responsible for correctness/security.