### PR TITLE
fix: raise default tx expiry delta from 2 to 5 blocks

### DIFF
--- a/src/fee_policy.rs
+++ b/src/fee_policy.rs
@@ -8,8 +8,8 @@ pub const MARGINAL_FEE_ZATOSHIS: u64 = 5_000;
 pub const GRACE_ACTIONS: u32 = 2;
 /// Pilot priority multiplier when the user opts in.
 pub const PRIORITY_MULTIPLIER: u64 = 4;
-/// Default transaction expiry delta (~2 minutes at 75s/block).
-pub const PILOT_EXPIRY_DELTA_BLOCKS: u32 = 2;
+/// Default transaction expiry delta (~6 minutes at 75s/block).
+pub const PILOT_EXPIRY_DELTA_BLOCKS: u32 = 5;
 /// Last-resort fee if shape computation overflows (should not happen in practice).
 pub const FALLBACK_FEE_ZATOSHIS: u64 = 10_000;
 


### PR DESCRIPTION
Motivation: PILOT_EXPIRY_DELTA_BLOCKS = 2 → expiry tip + 2 (~2.5 min). On mainnet that's too tight; a tx not mined within ~2 blocks expires and is dropped unmined (observed in practice).

Change: raise default to 5 (~6 min). One-line const in src/fee_policy.rs.

Test evidence: with delta 2 a send expired unmined; with delta 5 the same send mined within the window.

Maintainer alignment: approved by @Lowo (Signal).
AI disclosure: implemented with Claude Code (Anthropic); constant change + this text. Human author responsible.