### PR TITLE
fix(api): sync balance persistence + dynamic-fee speed-up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+### Added
+
+- **Dynamic-fee pilot speed-up:** `POST /api/transaction/speed-up` rebuilds a new priority transaction after expiry (not a rebroadcast). Core logic in `nozy::tx_lifecycle`.
+- **Expired transaction detection:** pending pilot txs past `expiry_height` are marked `Expired` and release locally locked notes via `/api/transaction/check-confirmations`.
+
+### Fixed
+
+- **`/api/sync` repeat calls:** when already caught up to chain tip, return cached balance without rescanning; serialize concurrent syncs; richer sync response (`balance_zatoshis`, `already_synced`, `total_notes`).
+- **api-server send:** mark notes spent in `notes.json` after broadcast (match CLI).
+- **Transaction history note marking:** use v2 `notes.json` index format when marking spent notes.
+
 ## [2.3.6.2] — Teriyaki Hot (CLI) (2026-06-16)
 
 Patch on **v2.3.6.1**. Crate SemVer remains **2.3.6** until next release bump.

--- a/api-server/src/handlers.rs
+++ b/api-server/src/handlers.rs
@@ -5,6 +5,14 @@ use axum::{
 };
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::sync::OnceLock;
+use tokio::sync::Mutex;
+
+static WALLET_SYNC_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+fn wallet_sync_lock() -> &'static Mutex<()> {
+    WALLET_SYNC_LOCK.get_or_init(|| Mutex::new(()))
+}
 
 #[allow(dead_code)]
 pub fn error_response(
@@ -86,7 +94,14 @@ pub struct BalanceResponse {
 pub struct SyncResponse {
     pub success: bool,
     pub balance_zec: f64,
+    pub balance_zatoshis: u64,
+    /// Total unspent notes in the persisted wallet cache (not just this scan).
     pub notes_found: usize,
+    pub total_notes: usize,
+    pub new_notes_in_scan: usize,
+    pub last_scan_height: u32,
+    pub chain_tip: u32,
+    pub already_synced: bool,
     pub message: String,
 }
 
@@ -391,6 +406,8 @@ pub async fn sync_wallet(
 ) -> Result<ResponseJson<SyncResponse>, (StatusCode, ResponseJson<serde_json::Value>)> {
     use nozy::{sync_wallet_notes, WalletSyncOptions};
 
+    let _sync_guard = wallet_sync_lock().lock().await;
+
     let (wallet, _storage) = load_wallet_with_password(payload.password)
         .await
         .map_err(|e| {
@@ -410,14 +427,28 @@ pub async fn sync_wallet(
     match sync_wallet_notes(wallet, options).await {
         Ok(result) => {
             let balance_zec = result.balance_zatoshis as f64 / 100_000_000.0;
+            let message = if result.already_synced {
+                format!(
+                    "Wallet already synced to tip (height {}). Cached balance: {balance_zec:.8} ZEC",
+                    result.chain_tip
+                )
+            } else {
+                format!(
+                    "Sync completed for blocks {}-{}. Balance: {balance_zec:.8} ZEC",
+                    result.scan_start, result.scan_end
+                )
+            };
             Ok(ResponseJson(SyncResponse {
                 success: true,
                 balance_zec,
+                balance_zatoshis: result.balance_zatoshis,
                 notes_found: result.unspent_notes,
-                message: format!(
-                    "Sync completed for blocks {}-{}. Balance: {balance_zec:.8} ZEC",
-                    result.scan_start, result.scan_end
-                ),
+                total_notes: result.total_notes,
+                new_notes_in_scan: result.new_notes_in_scan,
+                last_scan_height: result.last_scan_height,
+                chain_tip: result.chain_tip,
+                already_synced: result.already_synced,
+                message,
             }))
         }
         Err(e) => Err((
@@ -606,6 +637,8 @@ pub async fn send_transaction(
                     .iter()
                     .map(|note| hex::encode(note.orchard_note.nullifier.to_bytes()))
                     .collect();
+
+                let _ = nozy::mark_wallet_notes_spent_from_spendables(&spendable_notes);
 
                 let mut tx_record = SentTransactionRecord::new_pilot(
                     network_txid.clone(),
@@ -1048,6 +1081,10 @@ pub async fn check_transaction_confirmations(
         .check_all_pending_transactions(&zebra_client)
         .await
         .unwrap_or(0);
+    let expired_updated = tx_storage
+        .check_expired_pending_transactions(&zebra_client)
+        .await
+        .unwrap_or(0);
     let updated_confirmations = tx_storage
         .update_confirmations(&zebra_client)
         .await
@@ -1055,8 +1092,65 @@ pub async fn check_transaction_confirmations(
 
     Ok(ResponseJson(serde_json::json!({
         "pending_updated": updated_pending,
+        "expired_updated": expired_updated,
         "confirmations_updated": updated_confirmations
     })))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SpeedUpTransactionRequest {
+    pub original_txid: String,
+    pub password: Option<String>,
+    pub zebra_url: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SpeedUpTransactionResponse {
+    pub success: bool,
+    pub txid: Option<String>,
+    pub original_txid: String,
+    pub message: String,
+}
+
+pub async fn speed_up_transaction(
+    Json(payload): Json<SpeedUpTransactionRequest>,
+) -> Result<ResponseJson<SpeedUpTransactionResponse>, (StatusCode, ResponseJson<serde_json::Value>)>
+{
+    use nozy::{load_config, speed_up_transaction as core_speed_up};
+
+    let config = load_config();
+    let zebra_url = payload
+        .zebra_url
+        .unwrap_or_else(|| config.zebra_url.clone());
+
+    let (wallet, _storage) = load_wallet_with_password(payload.password)
+        .await
+        .map_err(|e| {
+            (
+                StatusCode::UNAUTHORIZED,
+                ResponseJson(serde_json::json!({
+                    "error": e
+                })),
+            )
+        })?;
+
+    match core_speed_up(wallet, &zebra_url, &payload.original_txid).await {
+        Ok(new_txid) => Ok(ResponseJson(SpeedUpTransactionResponse {
+            success: true,
+            txid: Some(new_txid.clone()),
+            original_txid: payload.original_txid.clone(),
+            message: format!(
+                "Speed-up transaction broadcast. New TXID: {new_txid} (replaces {})",
+                payload.original_txid
+            ),
+        })),
+        Err(e) => Err((
+            StatusCode::BAD_REQUEST,
+            ResponseJson(serde_json::json!({
+                "error": e.to_string()
+            })),
+        )),
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/api-server/src/main.rs
+++ b/api-server/src/main.rs
@@ -81,6 +81,10 @@ async fn main() -> anyhow::Result<()> {
             "/api/transaction/check-confirmations",
             post(handlers::check_transaction_confirmations),
         )
+        .route(
+            "/api/transaction/speed-up",
+            post(handlers::speed_up_transaction),
+        )
         .route("/api/address-book", get(handlers::list_address_book))
         .route("/api/address-book", post(handlers::add_address_book_entry))
         .route(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,6 +85,8 @@ pub mod transaction_history;
 #[cfg(feature = "native")]
 pub mod transaction_tracker;
 #[cfg(feature = "native")]
+pub mod tx_lifecycle;
+#[cfg(feature = "native")]
 pub mod wallet_sync;
 #[cfg(feature = "native")]
 pub mod zeaking_adapter;
@@ -140,7 +142,8 @@ pub use note_index::NoteIndex;
 pub use note_sync::{NoteSyncManager, SyncResult};
 #[cfg(feature = "native")]
 pub use notes::{
-    load_wallet_notes, merge_scanned_notes, save_wallet_notes, wallet_unspent_balance_zatoshis,
+    load_wallet_notes, mark_wallet_notes_spent_from_spendables, merge_scanned_notes,
+    release_wallet_notes_by_nullifier_hex, save_wallet_notes, wallet_unspent_balance_zatoshis,
     NoteScanResult, NoteScanner, OrchardNote, SerializableOrchardNote, SpendableNote,
 };
 #[cfg(feature = "native")]
@@ -176,6 +179,8 @@ pub use transaction_builder::ZcashTransactionBuilder;
 pub use transaction_history::{
     SentTransactionRecord, TransactionStatus, TransactionType, TransactionView,
 };
+#[cfg(feature = "native")]
+pub use tx_lifecycle::{expire_stale_pending_transactions, speed_up_transaction};
 #[cfg(feature = "native")]
 pub use wallet_sync::{
     resolve_scan_range, sync_wallet_notes, ScanRange, WalletSyncOptions, WalletSyncResult,

--- a/src/notes.rs
+++ b/src/notes.rs
@@ -228,6 +228,39 @@ pub fn wallet_unspent_balance_zatoshis(notes: &[SerializableOrchardNote]) -> u64
         .sum()
 }
 
+/// Release notes marked spent locally when a pilot tx expires unmined.
+#[cfg(feature = "native")]
+pub fn release_wallet_notes_by_nullifier_hex(nullifier_hexes: &[String]) -> NozyResult<usize> {
+    use std::collections::HashSet;
+
+    if nullifier_hexes.is_empty() {
+        return Ok(0);
+    }
+
+    let targets: HashSet<Vec<u8>> = nullifier_hexes
+        .iter()
+        .filter_map(|h| hex::decode(h.trim()).ok())
+        .collect();
+    if targets.is_empty() {
+        return Ok(0);
+    }
+
+    let mut notes = load_wallet_notes()?;
+    let mut released = 0usize;
+    for note in &mut notes {
+        if note.spent && targets.contains(&note.nullifier_bytes) {
+            note.spent = false;
+            released += 1;
+        }
+    }
+
+    if released > 0 {
+        save_wallet_notes(&notes)?;
+    }
+
+    Ok(released)
+}
+
 /// Merge notes discovered during a scan into an existing cache.
 #[cfg(feature = "native")]
 pub fn merge_scanned_notes(

--- a/src/transaction_history.rs
+++ b/src/transaction_history.rs
@@ -48,6 +48,10 @@ pub struct SentTransactionRecord {
     /// Absolute chain height after which the tx must not be mined (pilot: tip + 2).
     #[serde(default)]
     pub expiry_height: Option<u32>,
+
+    /// When this tx is a speed-up replacement, the original txid it replaces.
+    #[serde(default)]
+    pub speed_up_of_txid: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -151,6 +155,7 @@ impl SentTransactionRecord {
             spent_note_ids,
             priority: false,
             expiry_height: None,
+            speed_up_of_txid: None,
         }
     }
 
@@ -179,6 +184,33 @@ impl SentTransactionRecord {
             spent_note_ids,
             priority,
             expiry_height: Some(expiry_height),
+            speed_up_of_txid: None,
+        }
+    }
+
+    pub fn new_speed_up(
+        txid: String,
+        original: &SentTransactionRecord,
+        fee_zatoshis: u64,
+        expiry_height: u32,
+        spent_note_ids: Vec<String>,
+    ) -> Self {
+        Self {
+            txid,
+            recipient_address: original.recipient_address.clone(),
+            amount_zatoshis: original.amount_zatoshis,
+            fee_zatoshis,
+            memo: original.memo.clone(),
+            created_at: Utc::now(),
+            broadcast_at: None,
+            status: TransactionStatus::Pending,
+            block_height: None,
+            block_time: None,
+            confirmations: 0,
+            spent_note_ids,
+            priority: true,
+            expiry_height: Some(expiry_height),
+            speed_up_of_txid: Some(original.txid.clone()),
         }
     }
 
@@ -584,6 +616,78 @@ impl SentTransactionStorage {
         Ok(updated_count)
     }
 
+    /// Mark pending pilot txs as expired when chain tip passes `expiry_height` without confirmation.
+    pub async fn check_expired_pending_transactions(
+        &self,
+        zebra_client: &crate::zebra_integration::ZebraClient,
+    ) -> NozyResult<usize> {
+        use crate::notes::release_wallet_notes_by_nullifier_hex;
+
+        let current_height = zebra_client.get_block_count().await.unwrap_or(0);
+        let expired_candidates: Vec<(String, Vec<String>)> = {
+            let transactions = self
+                .transactions
+                .lock()
+                .map_err(|e| NozyError::Storage(format!("Mutex poisoned: {}", e)))?;
+            transactions
+                .values()
+                .filter(|tx| {
+                    tx.status == TransactionStatus::Pending
+                        && tx.expiry_height.is_some_and(|exp| current_height > exp)
+                })
+                .map(|tx| (tx.txid.clone(), tx.spent_note_ids.clone()))
+                .collect()
+        };
+
+        let mut expired_count = 0usize;
+        for (txid, spent_note_ids) in expired_candidates {
+            if zebra_client
+                .check_transaction_exists(&txid)
+                .await
+                .unwrap_or(false)
+            {
+                continue;
+            }
+
+            let marked = self.mark_transaction_expired(&txid)?;
+            if marked {
+                let _ = release_wallet_notes_by_nullifier_hex(&spent_note_ids);
+                expired_count += 1;
+            }
+        }
+
+        Ok(expired_count)
+    }
+
+    pub fn mark_transaction_expired(&self, txid: &str) -> NozyResult<bool> {
+        let mut updated = false;
+        {
+            let mut transactions = self
+                .transactions
+                .lock()
+                .map_err(|e| NozyError::Storage(format!("Mutex poisoned: {}", e)))?;
+            if let Some(tx) = transactions.get_mut(txid) {
+                if tx.status == TransactionStatus::Pending {
+                    tx.mark_expired();
+                    updated = true;
+                }
+            }
+        }
+
+        if updated {
+            self.save_transactions()?;
+        }
+
+        Ok(updated)
+    }
+
+    pub fn get_transaction_record(&self, txid: &str) -> Option<SentTransactionRecord> {
+        self.transactions
+            .lock()
+            .ok()
+            .and_then(|transactions| transactions.get(txid).cloned())
+    }
+
     pub async fn update_confirmations(
         &self,
         zebra_client: &crate::zebra_integration::ZebraClient,
@@ -615,13 +719,7 @@ impl SentTransactionStorage {
     }
 
     pub fn mark_spent_notes_for_confirmed_transactions(&self) -> NozyResult<usize> {
-        use crate::paths::get_wallet_data_dir;
-        use std::fs;
-
-        let notes_path = get_wallet_data_dir().join("notes.json");
-        if !notes_path.exists() {
-            return Ok(0);
-        }
+        use crate::notes::{load_wallet_notes, save_wallet_notes};
 
         let confirmed_txs: Vec<(String, Vec<String>)> = {
             self.transactions.lock()
@@ -641,11 +739,7 @@ impl SentTransactionStorage {
             return Ok(0);
         }
 
-        let content = fs::read_to_string(&notes_path)
-            .map_err(|e| NozyError::Storage(format!("Failed to read notes: {}", e)))?;
-
-        let mut notes: Vec<crate::notes::SerializableOrchardNote> = serde_json::from_str(&content)
-            .map_err(|e| NozyError::Storage(format!("Failed to parse notes: {}", e)))?;
+        let mut notes = load_wallet_notes()?;
 
         let spent_nullifiers: std::collections::HashSet<Vec<u8>> = confirmed_txs
             .iter()
@@ -662,10 +756,7 @@ impl SentTransactionStorage {
         }
 
         if marked_count > 0 {
-            let serialized = serde_json::to_string_pretty(&notes)
-                .map_err(|e| NozyError::Storage(format!("Failed to serialize notes: {}", e)))?;
-            fs::write(&notes_path, serialized)
-                .map_err(|e| NozyError::Storage(format!("Failed to write notes: {}", e)))?;
+            save_wallet_notes(&notes)?;
         }
 
         Ok(marked_count)

--- a/src/tx_lifecycle.rs
+++ b/src/tx_lifecycle.rs
@@ -1,0 +1,158 @@
+//! Dynamic-fee pilot lifecycle: expiry detection, balance release, and speed-up rebuild.
+
+use crate::cli_helpers::scan_notes_for_sending;
+use crate::error::{NozyError, NozyResult};
+use crate::fee_policy::{
+    estimate_orchard_send_fee_zatoshis, PilotSendOptions, PILOT_EXPIRY_DELTA_BLOCKS,
+};
+use crate::hd_wallet::HDWallet;
+use crate::notes::mark_wallet_notes_spent_from_spendables;
+use crate::transaction_builder::ZcashTransactionBuilder;
+use crate::transaction_history::{
+    SentTransactionRecord, SentTransactionStorage, TransactionStatus,
+};
+use crate::zebra_integration::ZebraClient;
+use orchard::keys::FullViewingKey;
+
+/// Expire unmined pilot txs past `expiry_height` and release their pending note locks.
+pub async fn expire_stale_pending_transactions(zebra_client: &ZebraClient) -> NozyResult<usize> {
+    let tx_storage = SentTransactionStorage::new()?;
+    tx_storage
+        .check_expired_pending_transactions(zebra_client)
+        .await
+}
+
+/// Rebuild a brand-new priority transaction after the original expired (not a rebroadcast).
+pub async fn speed_up_transaction(
+    wallet: HDWallet,
+    zebra_url: &str,
+    original_txid: &str,
+) -> NozyResult<String> {
+    let tx_storage = SentTransactionStorage::new()?;
+    let zebra_client = ZebraClient::new(zebra_url.to_string());
+
+    tx_storage
+        .check_expired_pending_transactions(&zebra_client)
+        .await?;
+
+    let original = tx_storage
+        .get_transaction_record(original_txid)
+        .ok_or_else(|| {
+            NozyError::InvalidOperation(format!(
+                "Transaction {original_txid} not found in wallet history"
+            ))
+        })?;
+
+    if original.status == TransactionStatus::Confirmed {
+        return Err(NozyError::InvalidOperation(
+            "Transaction already confirmed; speed-up is not applicable".to_string(),
+        ));
+    }
+
+    if original.status == TransactionStatus::Pending {
+        if let Some(expiry) = original.expiry_height {
+            let tip = zebra_client.get_block_count().await?;
+            if tip <= expiry {
+                return Err(NozyError::InvalidOperation(format!(
+                    "Transaction has not expired yet (expiry height {expiry}, tip {tip})"
+                )));
+            }
+            if zebra_client.check_transaction_exists(original_txid).await? {
+                return Err(NozyError::InvalidOperation(
+                    "Transaction is pending on chain; wait for confirmation instead of speed-up"
+                        .to_string(),
+                ));
+            }
+            tx_storage.mark_transaction_expired(original_txid)?;
+            let _ = crate::notes::release_wallet_notes_by_nullifier_hex(&original.spent_note_ids);
+        } else {
+            return Err(NozyError::InvalidOperation(
+                "Only pilot transactions with expiry can be sped up".to_string(),
+            ));
+        }
+    } else if original.status != TransactionStatus::Expired {
+        return Err(NozyError::InvalidOperation(format!(
+            "Speed-up requires an expired transaction (current status: {:?})",
+            original.status
+        )));
+    }
+
+    let refreshed = tx_storage
+        .get_transaction_record(original_txid)
+        .ok_or_else(|| NozyError::InvalidOperation("Transaction record disappeared".to_string()))?;
+    if refreshed.status != TransactionStatus::Expired {
+        return Err(NozyError::InvalidOperation(
+            "Transaction must be expired before speed-up".to_string(),
+        ));
+    }
+
+    let spendable_notes = scan_notes_for_sending(wallet, zebra_url).await?;
+    if spendable_notes.is_empty() {
+        return Err(NozyError::InvalidOperation(
+            "No spendable notes available for speed-up; sync the wallet first".to_string(),
+        ));
+    }
+
+    let memo = refreshed.memo.as_deref();
+    let pilot = PilotSendOptions {
+        priority: true,
+        expiry_delta_blocks: PILOT_EXPIRY_DELTA_BLOCKS,
+    };
+    let fee_zatoshis = estimate_orchard_send_fee_zatoshis(memo, true);
+    let total_needed = refreshed.amount_zatoshis.saturating_add(fee_zatoshis);
+    let available: u64 = spendable_notes.iter().map(|n| n.orchard_note.value).sum();
+    if available < total_needed {
+        return Err(NozyError::InvalidOperation(format!(
+            "Insufficient funds for speed-up: need {:.8} ZEC, have {:.8} ZEC",
+            total_needed as f64 / 100_000_000.0,
+            available as f64 / 100_000_000.0,
+        )));
+    }
+
+    let tip_height = zebra_client.get_best_block_height().await?;
+    let expiry_height = tip_height.saturating_add(pilot.expiry_delta_blocks);
+
+    let mut tx_builder = ZcashTransactionBuilder::new();
+    tx_builder.set_zebra_url(zebra_url);
+    tx_builder.enable_mainnet_broadcast();
+
+    let transaction = tx_builder
+        .build_send_transaction(
+            &zebra_client,
+            &spendable_notes,
+            &refreshed.recipient_address,
+            refreshed.amount_zatoshis,
+            fee_zatoshis,
+            memo,
+            pilot,
+        )
+        .await?;
+
+    let network_txid = tx_builder
+        .broadcast_transaction(&zebra_client, &transaction)
+        .await?;
+
+    let spent_note_ids: Vec<String> = spendable_notes
+        .iter()
+        .map(|note| {
+            let fvk = FullViewingKey::from(&note.spending_key);
+            hex::encode(note.orchard_note.note.nullifier(&fvk).to_bytes())
+        })
+        .collect();
+
+    if let Err(e) = mark_wallet_notes_spent_from_spendables(&spendable_notes) {
+        eprintln!("Warning: could not mark spent notes locally after speed-up: {e}");
+    }
+
+    let mut tx_record = SentTransactionRecord::new_speed_up(
+        network_txid.clone(),
+        &refreshed,
+        fee_zatoshis,
+        expiry_height,
+        spent_note_ids,
+    );
+    tx_record.mark_broadcast();
+    tx_storage.save_transaction(tx_record)?;
+
+    Ok(network_txid)
+}

--- a/src/wallet_sync.rs
+++ b/src/wallet_sync.rs
@@ -73,6 +73,8 @@ pub struct WalletSyncResult {
     pub chain_tip: u32,
     pub blocks_scanned: u32,
     pub last_scan_height: u32,
+    /// True when the wallet is already caught up to chain tip (no blocks scanned).
+    pub already_synced: bool,
 }
 
 /// Resolve inclusive scan bounds from config + options (no network I/O).
@@ -104,13 +106,6 @@ pub fn resolve_scan_range(
 
     let scan_end = requested_end.min(chain_tip);
 
-    if scan_start > scan_end {
-        return Err(NozyError::InvalidOperation(format!(
-            "start height ({scan_start}) is above effective end height ({scan_end}, zebrad tip {chain_tip}). \
-             Wait for zebrad to pass your wallet birthday, use a snapshot, or pass a lower start height."
-        )));
-    }
-
     Ok(ScanRange {
         scan_start,
         scan_end,
@@ -134,6 +129,24 @@ pub async fn sync_wallet_notes(
 
     let notes_before = load_wallet_notes()?;
     let total_before = notes_before.len();
+    let balance_before = wallet_unspent_balance_zatoshis(&notes_before);
+
+    // Already caught up: return cached balance without re-scanning or rewriting notes.json.
+    if range.scan_start > range.scan_end {
+        let last_scan_height = config.last_scan_height.unwrap_or(range.chain_tip);
+        return Ok(WalletSyncResult {
+            balance_zatoshis: balance_before,
+            unspent_notes: notes_before.iter().filter(|n| !n.spent).count(),
+            total_notes: notes_before.len(),
+            new_notes_in_scan: 0,
+            scan_start: range.scan_start,
+            scan_end: range.scan_end,
+            chain_tip: range.chain_tip,
+            blocks_scanned: 0,
+            last_scan_height,
+            already_synced: true,
+        });
+    }
 
     let mut note_scanner = NoteScanner::new(wallet, zebra_client);
     let (scan_result, _spendable) = note_scanner
@@ -144,7 +157,7 @@ pub async fn sync_wallet_notes(
     merge_scanned_notes(&mut cached_notes, &scan_result.notes);
     save_wallet_notes(&cached_notes)?;
 
-    let _ = update_last_scan_height(range.scan_end);
+    update_last_scan_height(range.scan_end)?;
 
     let balance_zatoshis = wallet_unspent_balance_zatoshis(&cached_notes);
     let unspent_notes = cached_notes.iter().filter(|n| !n.spent).count();
@@ -164,6 +177,7 @@ pub async fn sync_wallet_notes(
         chain_tip: range.chain_tip,
         blocks_scanned,
         last_scan_height: range.scan_end,
+        already_synced: false,
     })
 }
 
@@ -206,9 +220,35 @@ mod tests {
     }
 
     #[test]
-    fn rejects_start_above_end() {
+    fn already_at_tip_yields_empty_scan_range() {
         let config = test_config(Some(3_100_000), "mainnet");
         let opts = WalletSyncOptions::default();
-        assert!(resolve_scan_range(&config, &opts, 3_050_000).is_err());
+        let range = resolve_scan_range(&config, &opts, 3_050_000).unwrap();
+        assert!(range.scan_start > range.scan_end);
+    }
+
+    #[test]
+    fn merge_preserves_cached_notes_across_incremental_scans() {
+        use crate::notes::{merge_scanned_notes, SerializableOrchardNote};
+
+        let mut cached = vec![SerializableOrchardNote {
+            note_bytes: vec![1],
+            value: 250_000,
+            address_bytes: vec![0; 43],
+            nullifier_bytes: vec![1; 32],
+            block_height: 3_050_500,
+            txid: "abc".to_string(),
+            spent: false,
+            memo: vec![],
+            orchard_incremental_witness_hex: None,
+            orchard_witness_tip_height: None,
+            rho_bytes: None,
+            rseed_bytes: None,
+        }];
+
+        let scanned: Vec<SerializableOrchardNote> = vec![];
+        merge_scanned_notes(&mut cached, &scanned);
+        assert_eq!(cached.len(), 1);
+        assert_eq!(cached[0].value, 250_000);
     }
 }


### PR DESCRIPTION
## Summary
- Fixes repeat `POST /api/sync` returning `notes_found: 0` / `balance_zec: 0` when the wallet is already caught up to chain tip — returns cached balance from persisted `notes.json` instead of erroring or appearing empty.
- Serializes concurrent sync requests so two rapid sync calls cannot race and overwrite `notes.json`.
- Enriches `/api/sync` response with `balance_zatoshis`, `total_notes`, `new_notes_in_scan`, `last_scan_height`, `chain_tip`, and `already_synced`.
- Completes dynamic-fee pilot lifecycle: auto-expire unmined txs past `expiry_height`, release locally locked notes, and `POST /api/transaction/speed-up` to rebuild a new priority tx (not rebroadcast).

## Tester context
Community integrator reported: first `/api/sync` shows balance (e.g. 0.0025 ZEC) but second sync immediately after returns 0, and `GET /api/balance` also returns 0. This PR targets that deposit-verification flow.

## Test plan
- [ ] Build api-server from this branch: `cargo build -p nozywallet-api --release`
- [ ] Create/restore wallet, `POST /api/sync` twice in a row — second response should match first balance
- [ ] `GET /api/balance` should match `/api/sync` `balance_zatoshis` after sync
- [ ] Send with `priority: false`, wait past expiry, `POST /api/transaction/check-confirmations` — original tx becomes `Expired`, notes spendable again
- [ ] `POST /api/transaction/speed-up` with `original_txid` — new txid at ×4 fee, original stays `Expired`
- [ ] `cargo test -p nozy wallet_sync`

Made with [Cursor](https://cursor.com)