### PR TITLE
feat(ui): speed-up in desktop History and extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,14 @@
 
 ### Added
 
+- **Desktop History:** Speed up button on expired transactions (rebuild at priority ×4 fee via Tauri `speed_up_transaction`).
+- **Extension:** Pilot speed-up rebuilds a new priority transaction in WASM (replaces wrong rebroadcast retry for expired txs); optional companion API path when `companionPassword` is supplied.
 - **Dynamic-fee pilot speed-up:** `POST /api/transaction/speed-up` rebuilds a new priority transaction after expiry (not a rebroadcast). Core logic in `nozy::tx_lifecycle`.
 - **Expired transaction detection:** pending pilot txs past `expiry_height` are marked `Expired` and release locally locked notes via `/api/transaction/check-confirmations`.
+
+### Changed
+
+- **Extension:** `wallet_retry_broadcast` kept for failed pre-broadcast retries only; expired txs use `wallet_speed_up`.
 
 ### Fixed
 

--- a/browser-extension/background/companion-api.js
+++ b/browser-extension/background/companion-api.js
@@ -116,3 +116,34 @@ export async function companionLwdSyncCompactToTip(baseUrl, body) {
   if (!r.ok) throw new Error(await readErrorBody(r));
   return r.json();
 }
+
+/**
+ * Refresh pending pilot txs (mark expired, release notes on companion wallet).
+ * @param {string} [baseUrl]
+ */
+export async function companionCheckConfirmations(baseUrl) {
+  const base = normalizeCompanionBase(baseUrl);
+  const r = await fetch(`${base}/api/transaction/check-confirmations`, { method: "POST" });
+  if (!r.ok) throw new Error(await readErrorBody(r));
+  return r.json();
+}
+
+/**
+ * Rebuild an expired transaction at priority fee via companion api-server.
+ * @param {string} [baseUrl]
+ * @param {{ original_txid: string, password?: string, zebra_url?: string }} body
+ */
+export async function companionSpeedUpTransaction(baseUrl, body) {
+  const base = normalizeCompanionBase(baseUrl);
+  const r = await fetch(`${base}/api/transaction/speed-up`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      original_txid: body.original_txid,
+      password: body.password ?? "",
+      zebra_url: body.zebra_url
+    })
+  });
+  if (!r.ok) throw new Error(await readErrorBody(r));
+  return r.json();
+}

--- a/browser-extension/background/service-worker.js
+++ b/browser-extension/background/service-worker.js
@@ -11,26 +11,36 @@ import {
 import {
   buildBuiltTxStateEntry,
   buildFailedTxStateEntry,
+  buildSpeedUpTxStateEntry,
+  canSpeedUpTx,
   findRecentBuiltTxId,
+  isPilotTxExpired,
   nextLifecycleStateFromConfirmation,
   resolveTxidFromBroadcast
 } from "./tx-lifecycle.js";
 import {
   findReachableRpcEndpoint,
+  isWslStyleHost,
   normalizeRpcEndpoint,
+  parseJsonRpcResponse,
+  probeZebradRpcEndpoint,
   rpcGetBlockVerboseByHeight,
   rpcNetworkErrorMessage
 } from "./rpc-utils.js";
 import { selectNotesForSpend, rpcFallbackWithRequester } from "./tx-utils.js";
 import {
+  companionCheckConfirmations,
   companionLwdChainTip,
   companionLwdInfo,
   companionLwdSyncCompact,
   companionLwdSyncCompactToTip,
+  companionSpeedUpTransaction,
   companionStatus
 } from "./companion-api.js";
 
 const STORAGE_KEY = "nozy_wallet_state_v1";
+const RPC_CACHE_KEY = "nozy_zebra_rpc_cache_v1";
+const COMPANION_BASE_KEY = "nozy_companion_base_url";
 const MOBILE_SYNC_KEY = "nozy_mobile_sync_v1";
 const TX_STATE_KEY = "nozy_tx_state_v1";
 const SESSION_POLICY_KEY = "nozy_session_policy_v1";
@@ -255,20 +265,14 @@ function orchardWitnessFieldsFromNote(noteObj) {
 }
 
 async function _inlineRpcRequest(endpoint, method, params = []) {
-  const resp = await fetch(endpoint, {
+  const url = normalizeRpcEndpoint(endpoint);
+  const resp = await fetch(url, {
     method: "POST",
     headers: { "content-type": "application/json" },
     body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params })
   });
   if (!resp.ok) throw new Error(`RPC ${method} HTTP ${resp.status}`);
-  const body = await resp.json();
-  if (body?.error) {
-    const e = new Error(body.error.message || `RPC ${method} error`);
-    if (typeof body.error.code === "number") e.jsonRpcCode = body.error.code;
-    e.jsonRpcMethod = method;
-    throw e;
-  }
-  return body?.result ?? null;
+  return parseJsonRpcResponse(resp, url, method);
 }
 
 async function _inlineProveTransaction(params) {
@@ -311,8 +315,9 @@ async function _inlineProveTransaction(params) {
   }
 
   const spendValue = selected.reduce((acc, n) => acc + n.value, 0);
-  const targetHeight = Number(await _inlineRpcRequest(endpoint, "getblockcount", []));
-  const heightStr = String(targetHeight);
+  const chainTip = Number(await _inlineRpcRequest(endpoint, "getblockcount", []));
+  const txBuildHeight = chainTip + 1;
+  const heightStr = String(chainTip);
 
   const rpcReq = (at) => _inlineRpcRequest(endpoint, at.method, at.params ?? []);
   const orchardTree = await rpcFallbackWithRequester(rpcReq, [
@@ -337,7 +342,7 @@ async function _inlineProveTransaction(params) {
     if (!Number.isFinite(tip) || tip < 0) {
       throw new Error("Invalid orchard_witness_tip_height on note.");
     }
-    for (let h = tip + 1; h <= targetHeight; h += 1) {
+    for (let h = tip + 1; h <= chainTip; h += 1) {
       const block = await rpcGetBlockVerboseByHeight(endpoint, h);
       witnessHex = wasm.advance_orchard_witness_hex(witnessHex, JSON.stringify(block));
     }
@@ -347,7 +352,7 @@ async function _inlineProveTransaction(params) {
     selectedWitnesses.push({
       incremental_witness_hex: witnessHex,
       anchor_hex: anchorHex,
-      target_height: targetHeight
+      target_height: txBuildHeight
     });
   }
 
@@ -452,7 +457,7 @@ function parseFeeToZats(v) {
 
 async function buildTxPreflight(tx) {
   const { recipientAddress, amount, memo } = parseTxForOrchardV5(tx);
-  const fee = await estimateFeeZats();
+  const fee = await estimateFeeZats(memo);
   const proving = await callWorker("prove_transaction", {
     recipientAddress,
     walletAddress: session.address,
@@ -571,6 +576,139 @@ async function retryBroadcastById(id) {
   return String(txid);
 }
 
+async function pilotExpiryHeightForTip(chainTip) {
+  await ensureWasm();
+  const delta = Number(wasm.pilot_expiry_delta_blocks?.() ?? 5);
+  const tip = Number(chainTip);
+  if (!Number.isFinite(tip)) return null;
+  return tip + delta;
+}
+
+async function refreshTxExpiryStates() {
+  if (!session.rpcEndpoint) return;
+  let chainTip;
+  try {
+    chainTip = Number(await rpcCall("getblockcount", []));
+  } catch (_) {
+    return;
+  }
+  if (!Number.isFinite(chainTip)) return;
+
+  const state = await loadTxState();
+  const txs = Array.isArray(state.txs) ? state.txs : [];
+  let changed = false;
+
+  for (const tx of txs) {
+    if (!tx?.txid) continue;
+    if (tx.state !== "pending" && tx.state !== "broadcast") continue;
+    if (!tx.expiryHeight) continue;
+    if (!isPilotTxExpired(chainTip, tx.expiryHeight)) continue;
+    try {
+      const resp = await rpcCall("getrawtransaction", [tx.txid, true]);
+      const height = resp?.blockheight ?? resp?.blockHeight ?? resp?.block_height ?? null;
+      const bh = typeof height === "number" ? height : parseNumberMaybeHex(height);
+      if (Number.isFinite(bh) && bh > 0) continue;
+    } catch (_) {
+      // Not mined — eligible for expired.
+    }
+    tx.state = "expired";
+    tx.updatedAt = nowMs();
+    changed = true;
+  }
+
+  if (changed) {
+    await saveTxState({ txs, updatedAt: nowMs() });
+  }
+}
+
+async function speedUpTxById(id, opts = {}) {
+  await refreshTxExpiryStates();
+  const state = await loadTxState();
+  const txs = Array.isArray(state.txs) ? state.txs : [];
+  const tx = txs.find((t) => t.id === id);
+  if (!tx) throw new Error("Transaction record not found.");
+  if (!canSpeedUpTx(tx)) {
+    throw new Error(`Speed-up is not available for transaction state: ${tx.state}`);
+  }
+  if (!tx.txid) throw new Error("Speed-up requires a broadcast txid.");
+  if (!session.unlocked || !session.mnemonic) throw new Error("Wallet is locked.");
+
+  const companionBase = await loadCompanionBaseUrl();
+  const companionPassword = String(opts.companionPassword ?? "").trim();
+  if (companionPassword) {
+    try {
+      const result = await companionSpeedUpTransaction(companionBase, {
+        original_txid: tx.txid,
+        password: companionPassword,
+        zebra_url: session.rpcEndpoint
+      });
+      if (result?.success && result?.txid) {
+        await patchTxStateById(id, { state: "expired", error: null });
+        const chainTip = Number(await rpcCall("getblockcount", []));
+        const expiryHeight = await pilotExpiryHeightForTip(chainTip);
+        await appendTxState(
+          buildSpeedUpTxStateEntry({
+            id: crypto.randomUUID(),
+            origin: tx.origin || "",
+            proving: {
+              txid: result.txid,
+              recipientAddress: tx.recipientAddress,
+              amount: tx.amount,
+              fee: await estimateFeeZats(tx.memo || "", true),
+              memo: tx.memo || "",
+              inputs_used: tx.inputsUsed ?? 1,
+              rawTxHex: ""
+            },
+            createdAt: nowMs(),
+            speedUpOf: tx.txid,
+            expiryHeight
+          })
+        );
+        return String(result.txid);
+      }
+      if (result?.message) throw new Error(result.message);
+    } catch (e) {
+      if (!opts.allowWasmFallback) throw e;
+    }
+  }
+
+  const priorityFee = await estimateFeeZats(tx.memo || "", true);
+  const proving = await callWorker("prove_transaction", {
+    recipientAddress: tx.recipientAddress,
+    walletAddress: session.address,
+    mnemonic: session.mnemonic,
+    rpcEndpoint: session.rpcEndpoint,
+    amount: tx.amount,
+    fee: priorityFee,
+    memo: tx.memo || ""
+  });
+  if (!proving?.rawTxHex) {
+    throw new Error("Speed-up proving did not return rawTxHex");
+  }
+
+  const broadcastResult = await rpcCallWithRetry("sendrawtransaction", [proving.rawTxHex], {
+    retries: 3,
+    baseDelayMs: 400
+  });
+  const newTxid = resolveTxidFromBroadcast(broadcastResult, proving.txid);
+  const chainTip = Number(await rpcCall("getblockcount", []));
+  const expiryHeight = await pilotExpiryHeightForTip(chainTip);
+
+  await patchTxStateById(id, { state: "expired", error: null });
+  await appendTxState(
+    buildSpeedUpTxStateEntry({
+      id: crypto.randomUUID(),
+      origin: tx.origin || "",
+      proving: { ...proving, fee: priorityFee },
+      createdAt: nowMs(),
+      speedUpOf: tx.txid,
+      expiryHeight
+    })
+  );
+
+  return String(newTxid);
+}
+
 async function loadWalletState() {
   const state = await storageGet(STORAGE_KEY);
   return state || null;
@@ -578,6 +716,64 @@ async function loadWalletState() {
 
 async function saveWalletState(state) {
   await storageSet({ [STORAGE_KEY]: state });
+}
+
+async function loadRpcEndpointCache() {
+  const cached = await storageGet(RPC_CACHE_KEY);
+  return Array.isArray(cached) ? cached.filter((u) => typeof u === "string") : [];
+}
+
+async function rememberRpcEndpoint(endpoint) {
+  const url = String(endpoint ?? "").trim();
+  if (!url) return;
+  const prev = await loadRpcEndpointCache();
+  const next = [url, ...prev.filter((u) => u !== url)].slice(0, 8);
+  await storageSet({ [RPC_CACHE_KEY]: next });
+}
+
+async function loadCompanionBaseUrl() {
+  const raw = await storageGet(COMPANION_BASE_KEY);
+  const s = String(raw ?? "").trim().replace(/\/+$/, "");
+  return s || "http://127.0.0.1:3000";
+}
+
+async function persistRpcEndpoint(found) {
+  session.rpcEndpoint = found;
+  await rememberRpcEndpoint(found);
+  const existing = (await loadWalletState()) || {};
+  await saveWalletState({ ...existing, rpcEndpoint: session.rpcEndpoint });
+  return found;
+}
+
+async function autodetectZebradRpcEndpoint() {
+  const cached = await loadRpcEndpointCache();
+  const companionBase = await loadCompanionBaseUrl();
+  const found = await findReachableRpcEndpoint(session.rpcEndpoint, {
+    extraCandidates: cached,
+    companionBase
+  });
+  if (!found) {
+    throw new Error(
+      "Could not find Zebrad on localhost or WSL. Start zebrad in WSL, then run: " +
+        "wsl -d Ubuntu -- hostname -I (use http://<first-ip>:8232). " +
+        "Or: powershell -File C:\\Zebrad\\scripts\\get-wsl-rpc-url.ps1"
+    );
+  }
+  return persistRpcEndpoint(found);
+}
+
+/** Probe current RPC; auto-detect WSL/local Zebrad if saved URL (often 127.0.0.1) is wrong. */
+async function ensureReachableZebradRpc() {
+  let endpoint;
+  try {
+    endpoint = normalizeRpcEndpoint(session.rpcEndpoint);
+  } catch (e) {
+    throw e instanceof Error ? e : new Error(String(e));
+  }
+  if (await probeZebradRpcEndpoint(endpoint, 3500)) {
+    return endpoint;
+  }
+  return autodetectZebradRpcEndpoint();
 }
 
 async function loadMobileSyncState() {
@@ -876,10 +1072,20 @@ async function walletUnlock(password) {
     await persistScanResumeForBackground(mnemonic, address);
   }
 
+  try {
+    await ensureReachableZebradRpc();
+  } catch {
+    // User can fix RPC in Settings; unlock should still succeed.
+  }
+
   return { address };
 }
 
-function walletLock() {
+async function walletLock() {
+  const scan = await loadScanState();
+  if (scan?.status === "scanning") {
+    await stopBackgroundScan();
+  }
   session.unlocked = false;
   session.mnemonic = null;
   session.address = null;
@@ -943,9 +1149,13 @@ async function rpcCall(method, params = []) {
     });
   } catch (err) {
     // Auto-recover from common local RPC port mismatch (8232 vs 18232).
-    const fallbackEndpoint = await findReachableRpcEndpoint(endpoint);
+    const fallbackEndpoint = await findReachableRpcEndpoint(endpoint, {
+      extraCandidates: await loadRpcEndpointCache(),
+      companionBase: await loadCompanionBaseUrl()
+    });
     if (fallbackEndpoint && fallbackEndpoint !== endpoint) {
       session.rpcEndpoint = fallbackEndpoint;
+      await rememberRpcEndpoint(fallbackEndpoint);
       const existing = (await loadWalletState()) || {};
       await saveWalletState({ ...existing, rpcEndpoint: session.rpcEndpoint });
       resp = await fetch(fallbackEndpoint, {
@@ -969,11 +1179,26 @@ async function rpcCall(method, params = []) {
     );
   }
   if (!resp.ok) throw new Error(`RPC HTTP ${resp.status}`);
-  const body = await resp.json();
-  if (body.error) {
-    throw new Error(body.error.message || "RPC error");
+  try {
+    const result = await parseJsonRpcResponse(resp, endpoint, method);
+    try {
+      const host = new URL(endpoint).hostname;
+      if (isWslStyleHost(host) || host === "127.0.0.1" || host === "localhost") {
+        await rememberRpcEndpoint(endpoint);
+      }
+    } catch {
+      // ignore cache errors
+    }
+    return result;
+  } catch (parseErr) {
+    const msg = String(parseErr?.message ?? parseErr);
+    if (!/web page|not JSON|DOCTYPE|127\.0\.0\.1|localhost/i.test(msg)) {
+      throw parseErr;
+    }
+    const found = await autodetectZebradRpcEndpoint();
+    if (found === endpoint) throw parseErr;
+    return rpcCall(method, params);
   }
-  return body.result;
 }
 
 async function rpcCallWithRetry(method, params = [], opts = {}) {
@@ -1022,27 +1247,33 @@ async function getOrchardActivationHeight() {
   }
 }
 
-async function estimateFeeZats() {
+async function estimateFeeZats(memo = "", priority = false) {
   try {
-    const feeResult = await rpcCallWithRetry("estimatefee", [1], { retries: 1, baseDelayMs: 200 });
-    const fromRoot = parseFeeToZats(feeResult);
-    const fromObj = parseFeeToZats(feeResult?.feerate);
-    const candidate = fromRoot ?? fromObj;
-    if (candidate && candidate > 0) {
-      return Math.max(1_000, Math.min(candidate, 250_000));
-    }
+    await ensureWasm();
+    const fee = wasm.estimate_orchard_send_fee_zats(memo, Boolean(priority));
+    if (Number.isFinite(fee) && fee > 0) return fee;
   } catch (_) {
     // ignore and fallback
   }
-  return 10_000;
+  return priority ? 40_000 : 10_000;
 }
 
 setInterval(() => {
   if (!session.unlocked) return;
   if (!session.lastActivityAt) return;
-  if (nowMs() - session.lastActivityAt >= session.autoLockMs) {
-    walletLock();
-  }
+  // Keep wallet unlocked while a background Orchard scan is running (popup may be closed).
+  loadScanState()
+    .then((scan) => {
+      if (scan?.status === "scanning") return;
+      if (nowMs() - session.lastActivityAt >= session.autoLockMs) {
+        walletLock();
+      }
+    })
+    .catch(() => {
+      if (nowMs() - session.lastActivityAt >= session.autoLockMs) {
+        walletLock();
+      }
+    });
 }, 20_000);
 
 setInterval(() => {
@@ -1055,7 +1286,20 @@ const SCAN_BATCH = 50;
 /** First wake processes fewer blocks so the first `saveScanState` (and UI poll) happens sooner. */
 const SCAN_FIRST_BATCH = 12;
 /** Persist notes / tracker during a long batch so balance and storage do not stall until 50 blocks finish. */
-const SCAN_SAVE_EVERY_BLOCKS = 10;
+const SCAN_SAVE_EVERY_BLOCKS = 5;
+
+function scanPercentInt(state) {
+  const total = Math.max(1, (state.endHeight ?? 0) - (state.startHeight ?? 0) + 1);
+  const done =
+    typeof state.heightProgress === "number"
+      ? Math.min(total, Math.max(0, state.heightProgress - state.startHeight + 1))
+      : Math.min(total, state.scannedBlocks ?? 0);
+  return Math.min(100, Math.max(0, Math.floor((done / total) * 100)));
+}
+
+function scanRpcEndpoint(state) {
+  return session.rpcEndpoint || state?.rpcEndpoint || "http://127.0.0.1:8232";
+}
 const SCAN_ALARM = "nozy_scan_tick";
 const SCAN_MODE_MANUAL = "manual";
 const SCAN_MODE_AUTO = "auto";
@@ -1138,11 +1382,17 @@ async function scanTick() {
   scanRunning = true;
   try {
     await ensureSessionInitialized();
+    if (session.unlocked) touchSession();
     const resume = await readScanResumeForBackground();
     const mnemonicForScan = session.mnemonic || resume?.mnemonic || null;
     const addressForScan = session.address || resume?.address || null;
     if (!mnemonicForScan || !addressForScan) {
-      scheduleScanAlarm(1);
+      state.status = "failed";
+      state.scanError =
+        "Scan could not run: wallet session expired. Lock and unlock the wallet, then try Sync again.";
+      state.finishedAt = nowMs();
+      clearScanResumeForBackground();
+      await saveScanState(state);
       return;
     }
 
@@ -1208,9 +1458,26 @@ async function scanTick() {
     let blocksSinceProgressSave = 0;
     const loopStart = state.currentHeight;
     const failLimit = 30;
+    if (
+      (state.consecutiveFailures ?? 0) > 0 &&
+      typeof state.lastRpcError === "string" &&
+      /DOCTYPE|web page|not JSON|127\.0\.0\.1/i.test(state.lastRpcError)
+    ) {
+      try {
+        const fixed = await ensureReachableZebradRpc();
+        state.rpcEndpoint = fixed;
+        state.consecutiveFailures = 0;
+        state.lastRpcError = null;
+        await saveScanState(state);
+      } catch {
+        // keep failing with existing errors
+      }
+    }
+
+    const rpcEndpoint = scanRpcEndpoint(state);
     for (let h = loopStart; h <= end; h++) {
       try {
-        const block = await rpcGetBlockVerboseByHeight(session.rpcEndpoint, h);
+        const block = await rpcGetBlockVerboseByHeight(rpcEndpoint, h);
         if (block) {
           const blockJson = JSON.stringify(block);
           const out = wasm.orchard_scan_tracker_apply_block(
@@ -1262,8 +1529,11 @@ async function scanTick() {
         state.scannedBlocks = h - state.startHeight + 1;
         state.updatedAt = nowMs();
         blocksSinceProgressSave += 1;
-        if (blocksSinceProgressSave >= SCAN_SAVE_EVERY_BLOCKS) {
+        const pctInt = scanPercentInt(state);
+        const crossedPercent = pctInt > (state.lastSavedPercentInt ?? -1);
+        if (blocksSinceProgressSave >= SCAN_SAVE_EVERY_BLOCKS || crossedPercent) {
           blocksSinceProgressSave = 0;
+          if (crossedPercent) state.lastSavedPercentInt = pctInt;
           await saveScanState(state);
         }
       }
@@ -1295,6 +1565,9 @@ async function scanTick() {
 async function startBackgroundScan(startHeight, endHeight) {
   // User explicitly started a range (window / custom / birthday). Always replace any
   // in-progress job — otherwise "Last 500" is ignored while auto-sync is still "scanning".
+  if (session.unlocked && session.mnemonic && session.address) {
+    await persistScanResumeForBackground(session.mnemonic, session.address);
+  }
   const state = {
     status: "scanning",
     scanMode: SCAN_MODE_MANUAL,
@@ -1304,6 +1577,9 @@ async function startBackgroundScan(startHeight, endHeight) {
     scannedBlocks: 0,
     /** Highest block height fully processed this scan (for UI percent). */
     heightProgress: startHeight - 1,
+    /** Last integer percent persisted to storage (for UI step updates). */
+    lastSavedPercentInt: -1,
+    rpcEndpoint: scanRpcEndpoint({}),
     discoveredNotes: [],
     totalBalanceZats: 0,
     /** Serialized OrchardWitnessTracker JSON; required for Zebrad-style spends. */
@@ -1394,7 +1670,9 @@ async function startAutoBackgroundScan() {
     finishedAt: null,
     consecutiveFailures: 0,
     lastRpcError: null,
-    scanError: null
+    scanError: null,
+    lastSavedPercentInt: -1,
+    rpcEndpoint: scanRpcEndpoint({})
   };
   await saveScanState(state);
   scheduleScanAlarm(0.02);
@@ -1452,10 +1730,11 @@ chrome.runtime.onInstalled.addListener((details) => {
     .catch(() => undefined);
 });
 
-// Resume scan on service worker restart
+// Resume scan on service worker restart (popup closed / MV3 sleep).
 loadScanState().then((s) => {
   if (s && s.status === "scanning") {
-    scheduleScanAlarm(0.05);
+    scheduleScanAlarm(0.01);
+    void scanTick();
   }
 });
 
@@ -1485,7 +1764,7 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
           sendResponse(ok(await walletUnlock(params.password)));
           return;
         case "wallet_lock":
-          sendResponse(ok(walletLock()));
+          sendResponse(ok(await walletLock()));
           return;
         case "wallet_status":
           sendResponse(ok(await getWalletStatus()));
@@ -1544,10 +1823,24 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
           return;
         }
         case "wallet_get_transactions":
+          await refreshTxExpiryStates();
           sendResponse(ok(await loadTxState()));
           return;
         case "wallet_retry_broadcast":
           sendResponse(ok({ txid: await retryBroadcastById(String(params.id ?? "")) }));
+          return;
+        case "wallet_speed_up":
+          sendResponse(
+            ok({
+              txid: await speedUpTxById(String(params.id ?? ""), {
+                companionPassword: params.companionPassword,
+                allowWasmFallback: params.allowWasmFallback !== false
+              })
+            })
+          );
+          return;
+        case "companion_check_confirmations":
+          sendResponse(ok(await companionCheckConfirmations(params.baseUrl)));
           return;
         case "wallet_generate_address":
           if (!session.unlocked || !session.mnemonic) throw new Error("Wallet is locked");
@@ -1605,10 +1898,13 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
                   ], { retries: 3, baseDelayMs: 400 });
 
                   const txid = resolveTxidFromBroadcast(broadcastResult, proving.txid);
+                  const chainTip = Number(await rpcCall("getblockcount", []));
+                  const expiryHeight = await pilotExpiryHeightForTip(chainTip);
                   await patchTxStateById(txStateId, {
                     txid: String(txid),
                     state: "broadcast",
-                    error: null
+                    error: null,
+                    expiryHeight
                   });
 
                   const confirmation = await waitForTxConfirmation({
@@ -1678,11 +1974,34 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
           } catch (e) {
             throw e instanceof Error ? e : new Error(String(e));
           }
+          await rememberRpcEndpoint(session.rpcEndpoint);
           {
             const existing = (await loadWalletState()) || {};
             await saveWalletState({ ...existing, rpcEndpoint: session.rpcEndpoint });
           }
           sendResponse(ok({ rpcEndpoint: session.rpcEndpoint }));
+          return;
+        }
+        case "rpc_autodetect": {
+          const found = await autodetectZebradRpcEndpoint();
+          const blockCount = await rpcCallWithRetry("getblockcount", [], { retries: 1 });
+          sendResponse(
+            ok({
+              rpcEndpoint: found,
+              blockCount: typeof blockCount === "number" ? blockCount : Number(blockCount)
+            })
+          );
+          return;
+        }
+        case "rpc_probe_endpoint": {
+          const url = normalizeRpcEndpoint(String(params?.url ?? session.rpcEndpoint));
+          const okProbe = await probeZebradRpcEndpoint(url, 4000);
+          if (!okProbe) {
+            throw new Error(
+              `Zebrad not reachable at ${url}. If zebrad runs in WSL, use your WSL IP instead of 127.0.0.1.`
+            );
+          }
+          sendResponse(ok({ endpoint: url, connected: true }));
           return;
         }
         case "rpc_get_status":
@@ -1745,6 +2064,7 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
             throw new Error("Unlock wallet first.");
           }
           await persistScanResumeForBackground(session.mnemonic, session.address);
+          const rpcUrl = await ensureReachableZebradRpc();
           const blockCount = await rpcCallWithRetry("getblockcount", []);
 
           const rawEnd = params?.endHeight;
@@ -1759,19 +2079,45 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
           let startH;
           if (params.useBirthdayRange === true) {
             const ws = await loadWalletState();
+            const existingScan = await loadScanState();
             const bh = ws?.orchardBirthdayHeight;
             const orchardActivation = await getOrchardActivationHeight();
-            // With a saved birthday (set at create/restore): scan **creation height → tip** only — no blocks before
-            // the wallet existed (fast path for new Nozy users). Restored old seeds: set birthday lower or use NU5 / full chain presets.
+            let birthdayStart;
+            // With a saved birthday (set at create/restore): scan creation height → tip.
+            // Restored old seeds: set birthday lower or use Advanced custom scan.
             if (bh === undefined || bh === null || bh === "") {
-              startH = Math.max(0, Math.min(orchardActivation, endH));
+              birthdayStart = Math.max(0, Math.min(orchardActivation, endH));
             } else {
               const nb = Number(bh);
               if (!Number.isFinite(nb) || nb < 0) {
-                startH = Math.max(0, Math.min(orchardActivation, endH));
+                birthdayStart = Math.max(0, Math.min(orchardActivation, endH));
               } else {
-                startH = Math.max(0, Math.min(Math.floor(nb), endH));
+                birthdayStart = Math.max(0, Math.min(Math.floor(nb), endH));
               }
+            }
+            startH = birthdayStart;
+            // Resume from last scanned height when re-syncing to tip (incremental catch-up).
+            // If the user lowered birthday (e.g. CLI note at 3_276_066), do NOT skip blocks —
+            // a prior "done" scan from a higher start height must be rescanned from birthdayStart.
+            const priorScanStart =
+              typeof existingScan?.startHeight === "number"
+                ? Math.floor(existingScan.startHeight)
+                : birthdayStart;
+            const birthdayWasLowered = birthdayStart < priorScanStart;
+            if (
+              !birthdayWasLowered &&
+              existingScan &&
+              (existingScan.status === "done" ||
+                existingScan.status === "stopped" ||
+                existingScan.status === "failed") &&
+              typeof existingScan.heightProgress === "number" &&
+              existingScan.heightProgress >= birthdayStart - 1
+            ) {
+              startH = Math.min(endH, Math.floor(existingScan.heightProgress) + 1);
+            }
+            // Re-scan the tip block when already caught up (new deposits same height).
+            if (startH > endH) {
+              startH = endH;
             }
           } else {
             const rawStart = params?.startHeight;
@@ -1796,7 +2142,13 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
 
           const s = await startBackgroundScan(startH, endH);
           sendResponse(
-            ok({ started: true, startHeight: startH, endHeight: endH, status: s.status })
+            ok({
+              started: true,
+              startHeight: startH,
+              endHeight: endH,
+              status: s.status,
+              rpcEndpoint: rpcUrl
+            })
           );
           return;
         }
@@ -1809,7 +2161,15 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
             throw new Error("height must be a non-negative integer (Orchard scan birthday).");
           }
           const orchardBirthdayHeight = Math.floor(n);
+          const prevBh = Number(existing.orchardBirthdayHeight);
           await saveWalletState({ ...existing, orchardBirthdayHeight });
+          // Lower birthday requires rescanning older blocks; clear stale "done" scan metadata.
+          if (Number.isFinite(prevBh) && orchardBirthdayHeight < prevBh) {
+            const scan = await loadScanState();
+            if (scan && (scan.status === "done" || scan.status === "stopped" || scan.status === "failed")) {
+              await chrome.storage.local.remove(SCAN_STATE_KEY);
+            }
+          }
           sendResponse(ok({ orchardBirthdayHeight }));
           return;
         }
@@ -1828,8 +2188,8 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
             } else {
               done = Math.min(total, scanState.scannedBlocks ?? 0);
             }
-            // Keep decimal precision so very large scans don't look "stuck" at one integer percent.
             const pct = Number(((done / total) * 100).toFixed(2));
+            const percentInt = Math.min(100, Math.max(0, Math.floor(pct)));
             sendResponse(ok({
               status: scanState.status,
               startHeight: scanState.startHeight,
@@ -1838,6 +2198,7 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
               scannedBlocks: done,
               totalBlocks: total,
               percent: pct,
+              percentInt,
               discoveredNotes: scanState.discoveredNotes?.length ?? 0,
               totalBalanceZats: scanState.totalBalanceZats ?? 0,
               scanError: scanState.scanError ?? null,
@@ -1854,6 +2215,19 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
         case "wallet_stop_scan": {
           const stopped = await stopBackgroundScan();
           sendResponse(ok({ status: stopped?.status ?? "idle" }));
+          return;
+        }
+        case "wallet_estimate_send_fee": {
+          await ensureWasm();
+          const memo = String(params?.memo ?? "");
+          const priority = Boolean(params?.priority ?? false);
+          sendResponse(
+            ok({
+              fee: wasm.estimate_orchard_send_fee_zats(memo, priority),
+              expiry_delta_blocks: wasm.pilot_expiry_delta_blocks(),
+              core_version: wasm.nozy_version_display()
+            })
+          );
           return;
         }
         case "wallet_prove_transaction":

--- a/browser-extension/background/tx-lifecycle.js
+++ b/browser-extension/background/tx-lifecycle.js
@@ -66,3 +66,29 @@ export function findRecentBuiltTxId(txs, origin, now, windowMs = 5 * 60 * 1000) 
 export function nextLifecycleStateFromConfirmation(confirmation) {
   return confirmation?.confirmed ? "confirmed" : "pending";
 }
+
+/** True when chain tip is past the pilot expiry height. */
+export function isPilotTxExpired(chainTip, expiryHeight) {
+  const tip = Number(chainTip);
+  const exp = Number(expiryHeight);
+  if (!Number.isFinite(tip) || !Number.isFinite(exp)) return false;
+  return tip > exp;
+}
+
+/** Whether a local tx entry can use pilot speed-up (rebuild at priority fee). */
+export function canSpeedUpTx(tx) {
+  if (!tx) return false;
+  const state = String(tx.state || "");
+  return state === "expired";
+}
+
+export function buildSpeedUpTxStateEntry({ id, origin, proving, createdAt, speedUpOf, expiryHeight }) {
+  const base = buildBuiltTxStateEntry({ id, origin, proving, createdAt });
+  return {
+    ...base,
+    state: "broadcast",
+    priority: true,
+    speedUpOf: speedUpOf ? String(speedUpOf) : null,
+    expiryHeight: Number.isFinite(Number(expiryHeight)) ? Number(expiryHeight) : null
+  };
+}

--- a/browser-extension/background/tx-lifecycle.test.mjs
+++ b/browser-extension/background/tx-lifecycle.test.mjs
@@ -3,8 +3,10 @@ import assert from "node:assert/strict";
 import {
   buildBuiltTxStateEntry,
   buildFailedTxStateEntry,
+  canSpeedUpTx,
   findRecentBuiltTxId,
   inferInputMode,
+  isPilotTxExpired,
   nextLifecycleStateFromConfirmation,
   resolveTxidFromBroadcast
 } from "./tx-lifecycle.js";
@@ -72,4 +74,15 @@ test("findRecentBuiltTxId returns most recent matching built item", () => {
 test("nextLifecycleStateFromConfirmation maps confirm status", () => {
   assert.equal(nextLifecycleStateFromConfirmation({ confirmed: true }), "confirmed");
   assert.equal(nextLifecycleStateFromConfirmation({ confirmed: false }), "pending");
+});
+
+test("isPilotTxExpired compares tip to expiry height", () => {
+  assert.equal(isPilotTxExpired(100, 99), true);
+  assert.equal(isPilotTxExpired(99, 100), false);
+});
+
+test("canSpeedUpTx only allows expired local txs", () => {
+  assert.equal(canSpeedUpTx({ state: "expired" }), true);
+  assert.equal(canSpeedUpTx({ state: "pending" }), false);
+  assert.equal(canSpeedUpTx({ state: "failed" }), false);
 });

--- a/browser-extension/wasm-core/popup/src/App.tsx
+++ b/browser-extension/wasm-core/popup/src/App.tsx
@@ -11,18 +11,46 @@ import {
 import { TopNav } from "./components/TopNav";
 import { useUiStore } from "./store/uiStore";
 
-const NETWORK_RPC_PRESETS = {
-  mainnet: "https://zec.rocks:443",
-  testnet: "https://testnet.zec.rocks:443",
-  local18232: "http://127.0.0.1:18232",
-  local8232: "http://127.0.0.1:8232"
-} as const;
+/** Default when Zebrad runs natively on Windows (not WSL). */
+const DEFAULT_RPC = "http://127.0.0.1:8232";
 
-const NETWORK_LWD_PRESETS = {
-  mainnet: "https://zec.rocks:443/",
-  testnet: "https://testnet.zec.rocks:443/",
-  local: "http://127.0.0.1:9067"
-} as const;
+const NETWORK_RPC_OPTIONS = [
+  {
+    id: "mainnet-wsl",
+    label: "Mainnet — WSL Zebrad (auto-detect)",
+    url: "",
+    autodetect: true
+  },
+  {
+    id: "mainnet-local",
+    label: "Mainnet — Zebrad on this machine (127.0.0.1:8232)",
+    url: DEFAULT_RPC
+  },
+  {
+    id: "testnet-local",
+    label: "Testnet — local Zebrad (127.0.0.1:18232)",
+    url: "http://127.0.0.1:18232"
+  }
+] as const;
+
+function isWslZebradUrl(url: string): boolean {
+  return /^https?:\/\/172\.(1[6-9]|2\d|3[0-1])\.\d+\.\d+:8232\/?$/i.test(url.trim());
+}
+
+function scanPercentDisplay(scan: WalletScanProgressResult | null | undefined): number {
+  if (!scan) return 0;
+  if (typeof scan.percentInt === "number") return Math.min(100, Math.max(0, scan.percentInt));
+  return Math.min(100, Math.max(0, Math.floor(scan.percent ?? 0)));
+}
+
+function rpcPresetId(url: string): string {
+  if (isWslZebradUrl(url)) return "mainnet-wsl";
+  const hit = NETWORK_RPC_OPTIONS.find((o) => o.url && o.url === url);
+  return hit?.id ?? "custom";
+}
+
+/** Local lightwalletd only — public hosts (e.g. zec.rocks) are not offered here; they cannot scan blocks. */
+const DEFAULT_LWD_URL = "http://127.0.0.1:9067";
 
 function WelcomeView({
   onCreated,
@@ -160,22 +188,24 @@ function DashboardView({
   status,
   txs,
   onRetry,
+  onSpeedUp,
   scan
 }: {
   status: WalletStatus | null;
   txs: TxStateEntry[];
   onRetry: (id: string) => Promise<void>;
+  onSpeedUp: (id: string) => Promise<void>;
   scan: WalletScanProgressResult | null;
 }) {
   const [balanceZats, setBalanceZats] = useState<number | null>(null);
 
   const scanLabel = useMemo(() => {
     const p = scan;
-    if (!p || p.status === "idle") return "No scan yet — go to Receive tab to start";
-    if (p.status === "scanning") return `Scanning… ${p.percent ?? 0}%`;
-    if (p.status === "done") return `Scanned ${p.scannedBlocks ?? 0} blocks (complete)`;
-    if (p.status === "stopped") return `Scan stopped at ${p.percent ?? 0}%`;
-    if (p.status === "failed") return p.scanError ? `Scan failed — ${p.scanError}` : "Scan failed";
+    if (!p || p.status === "idle") return "Not synced yet — sync in Settings";
+    if (p.status === "scanning") return `Syncing… ${scanPercentDisplay(p)}%`;
+    if (p.status === "done") return `Synced ${p.scannedBlocks ?? 0} blocks`;
+    if (p.status === "stopped") return `Sync stopped at ${scanPercentDisplay(p)}%`;
+    if (p.status === "failed") return p.scanError ? `Sync failed — ${p.scanError}` : "Sync failed";
     return "";
   }, [scan]);
 
@@ -229,7 +259,15 @@ function DashboardView({
                   className="mt-1 rounded bg-white/10 px-2 py-1 text-[10px]"
                   onClick={() => onRetry(tx.id)}
                 >
-                  Retry Broadcast
+                  Retry broadcast
+                </button>
+              )}
+              {tx.state === "expired" && (
+                <button
+                  className="mt-1 rounded bg-amber-500/20 px-2 py-1 text-[10px] text-amber-100"
+                  onClick={() => onSpeedUp(tx.id)}
+                >
+                  Speed up (×4 fee)
                 </button>
               )}
             </div>
@@ -245,6 +283,7 @@ function SendView() {
   const [recipient, setRecipient] = useState("");
   const [amount, setAmount] = useState("");
   const [feeZats, setFeeZats] = useState("10000");
+  const [coreVersion, setCoreVersion] = useState<string>("");
   const [memo, setMemo] = useState("");
   const [rawTxHex, setRawTxHex] = useState<string | null>(null);
   const [preflight, setPreflight] = useState<{
@@ -256,6 +295,16 @@ function SendView() {
     selectedNotes: Array<{ value: number; cmx: string; block_height: number }>;
   } | null>(null);
   const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    extensionApi
+      .walletEstimateSendFee({ memo: memo || undefined })
+      .then((r) => {
+        setFeeZats(String(r.fee));
+        setCoreVersion(r.core_version);
+      })
+      .catch(() => undefined);
+  }, [memo]);
 
   async function runPreflight() {
     setBusy(true);
@@ -337,7 +386,7 @@ function SendView() {
           onChange={(e) => setFeeZats(e.target.value)}
         />
         <p className="mt-1 text-[10px] text-white/40">
-          Zebrad has no estimatefee RPC; set fee manually (10000 zats is a common default).
+          ZIP-317 conventional fee from core ({coreVersion || "nozy"}); adjust if needed. Zebrad has no estimatefee RPC.
         </p>
       </div>
 
@@ -405,27 +454,172 @@ function SendView() {
   );
 }
 
-/** Orchard (NU5) activation — use as scan start when you need “all Orchard” on that network. */
-const NU5_ORCHARD_START_MAINNET = 1_687_104;
-const NU5_ORCHARD_START_TESTNET = 1_842_420;
+function WalletSyncPanel({
+  status,
+  scan,
+  onScanProgress,
+  beforeSync
+}: {
+  status: WalletStatus | null;
+  scan: WalletScanProgressResult | null;
+  onScanProgress?: (p: WalletScanProgressResult) => void;
+  beforeSync?: () => Promise<void>;
+}) {
+  const [actionMsg, setActionMsg] = useState("");
+  const [infoMsg, setInfoMsg] = useState("");
+  const [busy, setBusy] = useState(false);
+  const scanning = busy || scan?.status === "scanning";
+  const percent = scanPercentDisplay(scan);
+
+  const statusLine = useMemo(() => {
+    if (!scan || scan.status === "idle") return null;
+    if (scan.status === "scanning") {
+      const done = scan.scannedBlocks ?? 0;
+      const total = scan.totalBlocks ?? 0;
+      const pct = scanPercentDisplay(scan);
+      const range =
+        typeof scan.startHeight === "number" && typeof scan.endHeight === "number"
+          ? ` · blocks ${scan.startHeight.toLocaleString()}–${scan.endHeight.toLocaleString()}`
+          : "";
+      return `${done.toLocaleString()} / ${total.toLocaleString()} blocks · ${pct}% · ${scan.discoveredNotes ?? 0} notes${range}`;
+    }
+    if (scan.status === "done") {
+      const zec = ((scan.totalBalanceZats ?? 0) / 1e8).toFixed(8);
+      return `Done — ${zec} ZEC · ${scan.discoveredNotes ?? 0} notes`;
+    }
+    if (scan.status === "failed" && scan.scanError) return scan.scanError;
+    if (scan.status === "stopped") return `Stopped at ${scan.percent ?? 0}%`;
+    return null;
+  }, [scan]);
+
+  const refreshScanProgress = async () => {
+    try {
+      const p = await extensionApi.walletScanProgress();
+      onScanProgress?.(p);
+      return p;
+    } catch {
+      return null;
+    }
+  };
+
+  const runSync = async (start: () => Promise<{ startHeight: number; endHeight: number }>) => {
+    setActionMsg("");
+    setInfoMsg("");
+    setBusy(true);
+    try {
+      if (beforeSync) await beforeSync();
+      const result = await start();
+      const blockCount = Math.max(1, result.endHeight - result.startHeight + 1);
+      const rpcNote =
+        "rpcEndpoint" in result && typeof result.rpcEndpoint === "string"
+          ? ` RPC: ${result.rpcEndpoint}.`
+          : "";
+      setInfoMsg(
+        `Scan started: ${result.startHeight.toLocaleString()} → ${result.endHeight.toLocaleString()} (${blockCount.toLocaleString()} blocks).${rpcNote} Large scans stay at 0% for a while — watch block counts below.`
+      );
+      await refreshScanProgress();
+      // Poll a few times quickly so the UI updates before the 2s app interval.
+      for (let i = 0; i < 5; i += 1) {
+        await new Promise((r) => setTimeout(r, 400));
+        const p = await refreshScanProgress();
+        if (p?.status === "scanning" && (p.scannedBlocks ?? 0) > 0) break;
+        if (p?.status === "done" || p?.status === "failed") break;
+      }
+    } catch (e) {
+      setActionMsg((e as Error).message);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (!status?.unlocked) return null;
+
+  return (
+    <div className="rounded border border-white/10 bg-white/5 p-3 text-sm space-y-2">
+      <div className="font-medium text-white/90">Sync wallet</div>
+      <p className="text-[11px] leading-snug text-white/50">
+        Scans Orchard notes via your RPC node (save Network above first). Required before sending.
+      </p>
+      {(scanning || scan?.status === "scanning") && (
+        <div className="h-2 w-full rounded bg-white/10 overflow-hidden">
+          <div
+            className="h-full bg-amber-500 transition-all duration-500"
+            style={{ width: `${Math.max(scanning && percent === 0 ? 2 : 0, percent)}%` }}
+          />
+        </div>
+      )}
+      <div className="flex flex-wrap gap-2">
+        {scan?.status !== "scanning" && !busy ? (
+          <>
+            <button
+              type="button"
+              className="rounded bg-amber-500 px-3 py-2 text-sm font-medium text-black disabled:opacity-50"
+              disabled={busy}
+              onClick={() =>
+                void runSync(() => extensionApi.walletStartScan({ useBirthdayRange: true }))
+              }
+            >
+              Sync to tip
+            </button>
+            <button
+              type="button"
+              className="rounded bg-white/10 px-3 py-2 text-xs text-white/80 disabled:opacity-50"
+              disabled={busy}
+              onClick={() => void runSync(() => extensionApi.walletStartScan(20_000))}
+            >
+              Last 20k blocks
+            </button>
+          </>
+        ) : (
+          <button
+            type="button"
+            className="rounded bg-red-600 px-3 py-2 text-sm text-white"
+            onClick={async () => {
+              setActionMsg("");
+              setInfoMsg("");
+              try {
+                await extensionApi.walletStopScan();
+                await refreshScanProgress();
+              } catch (_) {
+                /* ignore */
+              }
+            }}
+          >
+            Stop sync
+          </button>
+        )}
+      </div>
+      {typeof status.orchardBirthdayHeight === "number" && (
+        <div className="text-[10px] text-white/40">
+          Birthday height: {status.orchardBirthdayHeight.toLocaleString()}
+        </div>
+      )}
+      {infoMsg && <div className="text-xs text-green-300/90">{infoMsg}</div>}
+      {statusLine && <div className="text-xs text-white/65">{statusLine}</div>}
+      {scan?.lastRpcError && scan.status === "scanning" && (
+        <div className="text-[10px] text-amber-200/80">RPC: {scan.lastRpcError}</div>
+      )}
+      {actionMsg && <div className="text-xs text-red-300">{actionMsg}</div>}
+    </div>
+  );
+}
 
 function ReceiveView({ status }: { status: WalletStatus | null }) {
   return (
-    <div className="space-y-2 p-4 text-sm">
+    <div className="space-y-3 p-4 text-sm">
       <h2 className="text-base font-semibold">Receive</h2>
-      <div className="rounded border border-white/10 bg-white/5 p-3 break-all">
+      <div className="rounded border border-white/10 bg-white/5 p-3 break-all text-[11px] font-mono">
         {status?.address || "No address yet"}
       </div>
-      <p className="text-[11px] leading-snug text-white/60">
-        Share this unified address to receive shielded ZEC. Auto-sync runs in the background while unlocked.
-      </p>
-      <p className="text-[10px] leading-snug text-white/40">
-        Use the <span className="text-white/60">Scan</span> tab for manual ranges, birthday settings, and recovery rescans.
+      <p className="text-[11px] leading-snug text-white/55">
+        Share this unified address to receive shielded ZEC on mainnet. After receiving, sync in{" "}
+        <span className="text-white/75">Settings</span> to update your balance.
       </p>
     </div>
   );
 }
 
+/** Advanced scan controls (birthday, custom heights) — tucked under Settings → Advanced. */
 function ScanView({
   status,
   scan,
@@ -442,7 +636,9 @@ function ScanView({
   const [birthdayEditStr, setBirthdayEditStr] = useState("");
 
   const scanning = scan?.status === "scanning";
-  const percent = Math.min(100, Math.max(0, scan?.percent ?? 0));
+  const percent = scanPercentDisplay(scan);
+  const NU5_ORCHARD_START_MAINNET = 1_687_104;
+  const NU5_ORCHARD_START_TESTNET = 1_842_420;
 
   const scanInfo = useMemo(() => {
     if (!scan) return "";
@@ -456,7 +652,7 @@ function ScanView({
         typeof scan.lastRpcError === "string" && scan.lastRpcError.trim()
           ? ` — RPC: ${scan.lastRpcError.slice(0, 120)}${scan.lastRpcError.length > 120 ? "…" : ""}`
           : "";
-      return `Scanning… ${scan.percent ?? 0}% (${scan.scannedBlocks ?? 0}/${scan.totalBlocks ?? 0} blocks, ${scan.discoveredNotes ?? 0} notes, ${elapsed}s)${range}${warn}`;
+      return `Scanning… ${scanPercentDisplay(scan)}% (${scan.scannedBlocks ?? 0}/${scan.totalBlocks ?? 0} blocks, ${scan.discoveredNotes ?? 0} notes, ${elapsed}s)${range}${warn}`;
     }
     if (scan.status === "done") {
       const elapsed = ((scan.elapsed ?? 0) / 1000).toFixed(1);
@@ -464,7 +660,7 @@ function ScanView({
       return `Done in ${elapsed}s — ${scan.scannedBlocks ?? 0} blocks, ${scan.discoveredNotes ?? 0} notes, balance: ${zec} ZEC${range}`;
     }
     if (scan.status === "stopped") {
-      return `Scan stopped at ${scan.percent ?? 0}% (${scan.scannedBlocks ?? 0}/${scan.totalBlocks ?? 0} blocks)${range}`;
+      return `Scan stopped at ${scanPercentDisplay(scan)}% (${scan.scannedBlocks ?? 0}/${scan.totalBlocks ?? 0} blocks)${range}`;
     }
     if (scan.status === "failed") {
       return scan.scanError ? `Scan failed: ${scan.scanError}` : "Scan failed.";
@@ -591,8 +787,8 @@ function ScanView({
   };
 
   return (
-    <div className="space-y-2 p-4 text-sm">
-      <h2 className="text-base font-semibold">Scan</h2>
+    <div className="space-y-2 text-sm">
+      <h3 className="text-sm font-medium text-white/80">Custom scan</h3>
 
       {scanning && (
         <div className="h-1.5 w-full rounded bg-white/10 overflow-hidden">
@@ -604,13 +800,11 @@ function ScanView({
       )}
 
       <p className="text-[10px] leading-snug text-white/45">
-        <span className="text-white/60">Orchard-only</span> scan. Default scan uses your saved{" "}
-        <span className="text-white/60">creation height</span> (chain tip at create/restore, unless you change it) through
-        tip — no blocks before the wallet existed. Restored seed with older funds: lower birthday or use{" "}
-        <span className="text-white/60">NU5 → tip</span> / <span className="text-white/60">Full chain</span>.
+        For recovery or older funds: set birthday height or pick a block range. Normal use:{" "}
+        <span className="text-white/60">Sync to tip</span> above.
       </p>
 
-      <div className="rounded border border-white/10 bg-white/5 p-2 space-y-2 text-[11px]">
+      <div className="rounded border border-white/10 bg-black/20 p-2 space-y-2 text-[11px]">
         <div className="flex flex-wrap items-center justify-between gap-2">
           <span className="text-white/55">
             Chain tip:{" "}
@@ -646,14 +840,6 @@ function ScanView({
             />
           </label>
         </div>
-        <button
-          type="button"
-          disabled={scanning}
-          className="w-full rounded bg-amber-500 py-1.5 text-[12px] font-medium text-black disabled:opacity-40"
-          onClick={() => void startScanBirthdayToTip()}
-        >
-          Start scan (saved birthday → tip)
-        </button>
         <div className="border-t border-white/10 pt-2 space-y-1">
           <div className="text-[10px] text-white/45">
             Saved Orchard birthday (default scan start):{" "}
@@ -692,35 +878,11 @@ function ScanView({
         </div>
       </div>
 
-      <div className="text-[10px] text-white/40 space-y-0.5">
-        <div>Quick presets (end = current chain tip)</div>
-        <div className="text-white/35 leading-snug">
-          <span className="text-white/50">Last N:</span> scans only block heights{" "}
-          <span className="font-mono text-white/55">tip − N</span> through <span className="font-mono text-white/55">tip</span>{" "}
-          (both inclusive; that is <span className="font-mono text-white/55">N + 1</span> heights when the chain is long
-          enough). Your saved birthday is <span className="text-white/50">not</span> used for these buttons. Nothing
-          outside that interval is scanned.
-        </div>
-      </div>
       <div className="flex flex-wrap gap-2 items-center">
         {!scan ? (
           <span className="text-xs text-white/50 py-1">Checking scan status…</span>
         ) : !scanning ? (
           <>
-            <button
-              type="button"
-              className="rounded bg-emerald-600 px-2 py-1 text-[11px] font-medium text-white"
-              onClick={() => void startScanBirthdayToTip()}
-            >
-              Birthday → tip
-            </button>
-            <button
-              type="button"
-              className="rounded bg-amber-400 px-2 py-1 text-[11px] text-black"
-              onClick={() => void startScanWindow(500)}
-            >
-              Last 500
-            </button>
             <button
               type="button"
               className="rounded bg-amber-500 px-2 py-1 text-[11px] text-black"
@@ -731,16 +893,9 @@ function ScanView({
             <button
               type="button"
               className="rounded bg-amber-600/90 px-2 py-1 text-[11px] text-black"
-              onClick={() => void startScanWindow(100_000)}
+              onClick={() => void startScanCustomFields()}
             >
-              Last 100k
-            </button>
-            <button
-              type="button"
-              className="rounded bg-amber-700/80 px-2 py-1 text-[11px] text-white"
-              onClick={() => void startScanWindow(500_000)}
-            >
-              Last 500k
+              Custom range
             </button>
             {chainTip !== null && (
               <>
@@ -797,7 +952,7 @@ function ScanView({
 
 function CompanionView() {
   const [baseUrl, setBaseUrl] = useState("http://127.0.0.1:3000");
-  const [lwdUrl, setLwdUrl] = useState("https://testnet.zec.rocks:443/");
+  const [lwdUrl, setLwdUrl] = useState<string>(DEFAULT_LWD_URL);
   const [log, setLog] = useState("");
   const [busy, setBusy] = useState(false);
   const [syncStart, setSyncStart] = useState("0");
@@ -823,21 +978,11 @@ function CompanionView() {
   };
 
   return (
-    <div className="space-y-3 p-4 text-sm">
-      <h2 className="text-base font-semibold">Local API (lightwalletd)</h2>
-      <p className="text-[11px] leading-relaxed text-white/55">
-        <span className="font-medium text-white/75">Easiest full wallet:</span> install{" "}
-        <a
-          className="text-amber-300 underline"
-          href="https://github.com/LEONINE-DAO/Nozy-wallet/releases"
-          target="_blank"
-          rel="noreferrer"
-        >
-          Nozy Desktop
-        </a>{" "}
-        (Tauri). This tab is the <span className="text-white/70">lighter path</span>: WASM in the
-        extension + <span className="font-mono text-white/70">nozywallet-api</span> on your PC for
-        zeaking/lightwalletd compact sync—no Zebrad required on the same machine for that sync step.
+    <div className="space-y-3 text-sm">
+      <h3 className="text-sm font-medium text-white/80">Local API (optional)</h3>
+      <p className="text-[11px] leading-relaxed text-white/50">
+        Optional: run <span className="font-mono text-white/70">nozywallet-api</span> or Nozy Desktop
+        for lightwalletd compact sync. Zebrad JSON-RPC in Settings is enough for scan + send.
       </p>
 
       <div className="rounded border border-white/10 bg-white/5 p-3 space-y-2">
@@ -851,60 +996,24 @@ function CompanionView() {
           />
         </div>
         <div>
-          <div className="mb-1 text-[11px] text-white/60">lightwalletd gRPC (optional override)</div>
-          <div className="mb-2">
-            <div className="mb-1 text-[11px] text-white/60">Network preset</div>
-            <select
-              className="w-full rounded bg-white/10 p-2 text-xs outline-none"
-              onChange={(e) => {
-                const v = e.target.value;
-                if (v === "mainnet") setLwdUrl(NETWORK_LWD_PRESETS.mainnet);
-                else if (v === "testnet") setLwdUrl(NETWORK_LWD_PRESETS.testnet);
-                else if (v === "local") setLwdUrl(NETWORK_LWD_PRESETS.local);
-              }}
-              value={
-                lwdUrl === NETWORK_LWD_PRESETS.mainnet
-                  ? "mainnet"
-                  : lwdUrl === NETWORK_LWD_PRESETS.testnet
-                    ? "testnet"
-                    : lwdUrl === NETWORK_LWD_PRESETS.local
-                      ? "local"
-                      : "custom"
-              }
-            >
-              <option value="testnet">Testnet</option>
-              <option value="mainnet">Mainnet</option>
-              <option value="local">Local</option>
-              <option value="custom">Custom</option>
-            </select>
-          </div>
+          <div className="mb-1 text-[11px] text-white/60">lightwalletd gRPC (optional, local only)</div>
+          <p className="mb-2 text-[10px] leading-snug text-white/40">
+            For compact sync via the desktop API — not used for in-extension block scan (use Zebrad RPC in
+            Settings).
+          </p>
           <input
             className="w-full rounded bg-white/10 p-2 text-xs outline-none font-mono"
             value={lwdUrl}
             onChange={(e) => setLwdUrl(e.target.value)}
-            placeholder="https://testnet.zec.rocks:443/"
+            placeholder={DEFAULT_LWD_URL}
           />
           <div className="mt-2 flex flex-wrap gap-2 text-[11px]">
             <button
               type="button"
               className="rounded bg-white/10 px-2 py-1"
-              onClick={() => setLwdUrl("https://testnet.zec.rocks:443/")}
+              onClick={() => setLwdUrl(DEFAULT_LWD_URL)}
             >
-              Testnet zec.rocks
-            </button>
-            <button
-              type="button"
-              className="rounded bg-white/10 px-2 py-1"
-              onClick={() => setLwdUrl("https://zec.rocks:443/")}
-            >
-              Mainnet zec.rocks
-            </button>
-            <button
-              type="button"
-              className="rounded bg-white/10 px-2 py-1"
-              onClick={() => setLwdUrl("http://127.0.0.1:9067")}
-            >
-              Local 9067
+              Reset to local
             </button>
           </div>
         </div>
@@ -1072,91 +1181,170 @@ function SettingsView({
   endpoint,
   onEndpointChange,
   onLock,
-  onSetAutoLock
+  onSetAutoLock,
+  status,
+  scan,
+  onWalletMetaChanged,
+  onScanProgress
 }: {
   endpoint: string;
   onEndpointChange: (url: string) => void;
   onLock: () => void;
   onSetAutoLock: (ms: number) => Promise<void>;
+  status: WalletStatus | null;
+  scan: WalletScanProgressResult | null;
+  onWalletMetaChanged?: () => void;
+  onScanProgress?: (p: WalletScanProgressResult) => void;
 }) {
   const [value, setValue] = useState(endpoint);
   const [msg, setMsg] = useState<string | null>(null);
+  const [rpcBusy, setRpcBusy] = useState(false);
   const [autoLockMin, setAutoLockMin] = useState("15");
+  const [showAdvanced, setShowAdvanced] = useState(false);
+  const [showCustomRpc, setShowCustomRpc] = useState(() => rpcPresetId(endpoint) === "custom");
+  const preset = rpcPresetId(value);
+  const showWslUrlField = preset === "mainnet-wsl" || isWslZebradUrl(value);
 
   return (
     <div className="space-y-3 p-4 text-sm">
-      <h2 className="text-base font-semibold">Settings</h2>
+      <h2 className="text-base font-semibold">
+        Settings
+        <span className="ml-2 text-[10px] font-normal text-white/35">
+          v{chrome.runtime.getManifest().version}
+        </span>
+      </h2>
       <div>
-        <div className="mb-1 text-white/70">RPC endpoint</div>
-        <div className="mb-2">
-          <div className="mb-1 text-[11px] text-white/60">Network preset</div>
-          <select
-            className="w-full rounded bg-white/10 p-2 text-xs outline-none"
-            onChange={(e) => {
-              const v = e.target.value;
-              if (v === "mainnet") setValue(NETWORK_RPC_PRESETS.mainnet);
-              else if (v === "testnet") setValue(NETWORK_RPC_PRESETS.testnet);
-              else if (v === "local18232") setValue(NETWORK_RPC_PRESETS.local18232);
-              else if (v === "local8232") setValue(NETWORK_RPC_PRESETS.local8232);
-            }}
-            value={
-              value === NETWORK_RPC_PRESETS.mainnet
-                ? "mainnet"
-                : value === NETWORK_RPC_PRESETS.testnet
-                  ? "testnet"
-                  : value === NETWORK_RPC_PRESETS.local18232
-                    ? "local18232"
-                    : value === NETWORK_RPC_PRESETS.local8232
-                      ? "local8232"
-                      : "custom"
+        <div className="mb-1 text-white/70">Network</div>
+        <select
+          className="w-full rounded bg-white/10 p-2 text-xs outline-none"
+          value={preset === "custom" ? "custom" : preset}
+          onChange={(e) => {
+            const v = e.target.value;
+            if (v === "custom") {
+              setShowCustomRpc(true);
+              return;
             }
-          >
-            <option value="mainnet">Mainnet</option>
-            <option value="testnet">Testnet</option>
-            <option value="local18232">Local 18232</option>
-            <option value="local8232">Local 8232</option>
-            <option value="custom">Custom</option>
-          </select>
-        </div>
-        <input
-          className="w-full rounded bg-white/10 p-2 outline-none"
-          value={value}
-          onChange={(e) => setValue(e.target.value)}
-        />
-        <div className="mt-2 flex flex-wrap gap-2 text-xs">
-          <button
-            className="rounded bg-white/10 px-2 py-1"
-            onClick={() => setValue("http://127.0.0.1:18232")}
-          >
-            Local 18232
-          </button>
-          <button
-            className="rounded bg-white/10 px-2 py-1"
-            onClick={() => setValue("http://127.0.0.1:8232")}
-          >
-            Local 8232
-          </button>
-          <button
-            className="rounded bg-white/10 px-2 py-1"
-            onClick={() => setValue("https://zec.rocks:443")}
-          >
-            zec.rocks:443
-          </button>
-        </div>
-        <button
-          className="mt-2 rounded bg-amber-500 px-3 py-1 text-black"
-          onClick={async () => {
-            await onEndpointChange(value);
-            setMsg("Saved.");
+            setShowCustomRpc(false);
+            const opt = NETWORK_RPC_OPTIONS.find((o) => o.id === v);
+            if (opt) setValue(opt.url);
           }}
         >
-          Save
-        </button>
-        {msg && <div className="mt-1 text-xs text-green-300">{msg}</div>}
-        <div className="mt-1 text-[11px] text-white/60">
-          Tip: `zec.rocks443` is accepted and auto-normalized to `https://zec.rocks:443`.
+          {NETWORK_RPC_OPTIONS.map((o) => (
+            <option key={o.id} value={o.id}>
+              {o.label}
+            </option>
+          ))}
+          <option value="custom">Custom URL…</option>
+        </select>
+        {preset === "mainnet-wsl" && (
+          <p className="mt-2 text-[11px] text-amber-200/80 leading-snug">
+            Zebrad in WSL is not reachable at 127.0.0.1 from Windows. Click{" "}
+            <span className="font-medium">Auto-detect</span> (probes WSL IP) or paste{" "}
+            <span className="font-mono">http://&lt;WSL-IP&gt;:8232</span> from{" "}
+            <span className="font-mono">wsl -d Ubuntu -- hostname -I</span>.
+          </p>
+        )}
+        {(showCustomRpc || preset === "custom" || showWslUrlField) && (
+          <input
+            className="mt-2 w-full rounded bg-white/10 p-2 text-xs outline-none font-mono"
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            placeholder="http://172.20.199.206:8232"
+          />
+        )}
+        <div className="mt-2 flex flex-wrap gap-2">
+          <button
+            className="rounded bg-amber-500 px-3 py-1.5 text-sm font-medium text-black disabled:opacity-50"
+            disabled={rpcBusy}
+            onClick={async () => {
+              setRpcBusy(true);
+              setMsg(null);
+              try {
+                const { rpcEndpoint, blockCount } = await extensionApi.rpcAutodetect();
+                setValue(rpcEndpoint);
+                await onEndpointChange(rpcEndpoint);
+                setMsg(`Detected Zebrad at ${rpcEndpoint} (${blockCount.toLocaleString()} blocks).`);
+              } catch (e) {
+                setMsg((e as Error).message);
+              } finally {
+                setRpcBusy(false);
+              }
+            }}
+          >
+            {rpcBusy ? "Detecting…" : "Auto-detect Zebrad"}
+          </button>
+          <button
+            className="rounded bg-white/10 px-3 py-1.5 text-sm disabled:opacity-50"
+            disabled={rpcBusy || !value.trim()}
+            onClick={async () => {
+              setRpcBusy(true);
+              setMsg(null);
+              try {
+                await extensionApi.rpcProbeEndpoint(value.trim());
+                setMsg(`RPC OK at ${value.trim()}`);
+              } catch (e) {
+                setMsg((e as Error).message);
+              } finally {
+                setRpcBusy(false);
+              }
+            }}
+          >
+            Test RPC
+          </button>
+          <button
+            className="rounded bg-white/10 px-3 py-1.5 text-sm disabled:opacity-50"
+            disabled={rpcBusy || !value.trim()}
+            onClick={async () => {
+              await onEndpointChange(value);
+              setMsg("Network saved.");
+            }}
+          >
+            Save network
+          </button>
         </div>
+        {msg && (
+          <div
+            className={`mt-1 text-xs leading-snug ${
+              msg.includes("OK") || msg.includes("Detected") || msg === "Network saved."
+                ? "text-green-300"
+                : "text-amber-200"
+            }`}
+          >
+            {msg}
+          </div>
+        )}
+        <p className="mt-2 text-[11px] text-white/45 leading-snug">
+          Block scan needs Zebrad JSON-RPC (getblock / getblockhash). On Windows + WSL use your WSL IP,
+          not 127.0.0.1 — use Auto-detect above.
+        </p>
       </div>
+
+      <WalletSyncPanel
+        status={status}
+        scan={scan}
+        onScanProgress={onScanProgress}
+        beforeSync={async () => {
+          const trimmed = value.trim();
+          const looksPlaceholder = /x\.x\.x/i.test(trimmed) || !trimmed;
+          const looksWindowsLoopback =
+            /^https?:\/\/127\.0\.0\.1:8232\/?$/i.test(trimmed) ||
+            /^https?:\/\/localhost:8232\/?$/i.test(trimmed);
+          if (looksPlaceholder || looksWindowsLoopback) {
+            const { rpcEndpoint, blockCount } = await extensionApi.rpcAutodetect();
+            setValue(rpcEndpoint);
+            await onEndpointChange(rpcEndpoint);
+            setMsg(
+              `Using Zebrad at ${rpcEndpoint} (${blockCount.toLocaleString()} blocks) for sync.`
+            );
+            return;
+          }
+          if (trimmed !== endpoint) {
+            await onEndpointChange(trimmed);
+            setMsg("Network saved for sync.");
+          }
+        }}
+      />
+
       <button className="rounded bg-white/10 px-3 py-1" onClick={onLock}>
         Lock wallet
       </button>
@@ -1180,6 +1368,22 @@ function SettingsView({
           </button>
         </div>
       </div>
+
+      <button
+        type="button"
+        className="w-full rounded bg-white/10 px-3 py-2 text-left text-xs text-white/70"
+        onClick={() => setShowAdvanced((v) => !v)}
+      >
+        {showAdvanced ? "▾ Hide advanced" : "▸ Advanced (birthday, API, custom scan)"}
+      </button>
+      {showAdvanced && (
+        <div className="space-y-3 rounded border border-white/10 bg-white/5 p-3">
+          <ScanView status={status} scan={scan} onWalletMetaChanged={onWalletMetaChanged} />
+          <div className="border-t border-white/10 pt-3">
+            <CompanionView />
+          </div>
+        </div>
+      )}
     </div>
   );
 }
@@ -1253,7 +1457,7 @@ export function App() {
   const [bootDebug, setBootDebug] = useState<string | null>(null);
   /** Orchard block scan progress; polled app-wide so it keeps updating when you leave Receive. */
   const [scanProgress, setScanProgress] = useState<WalletScanProgressResult | null>(null);
-  const endpoint = useMemo(() => status?.rpcEndpoint || "http://127.0.0.1:8232", [status]);
+  const endpoint = useMemo(() => status?.rpcEndpoint || DEFAULT_RPC, [status]);
 
   const refresh = async () => {
     try {
@@ -1306,12 +1510,30 @@ export function App() {
       }
     }
     tick();
-    const id = setInterval(tick, 2000);
+    let id = setInterval(tick, 2000);
     return () => {
       cancelled = true;
       clearInterval(id);
     };
   }, [status?.unlocked]);
+
+  // Poll faster while scanning so each integer % step is visible.
+  useEffect(() => {
+    if (!status?.unlocked || scanProgress?.status !== "scanning") return;
+    let cancelled = false;
+    const fast = setInterval(async () => {
+      try {
+        const p = await extensionApi.walletScanProgress();
+        if (!cancelled) setScanProgress(p);
+      } catch {
+        /* ignore transient poll errors */
+      }
+    }, 400);
+    return () => {
+      cancelled = true;
+      clearInterval(fast);
+    };
+  }, [status?.unlocked, scanProgress?.status]);
 
   const autoSyncHeights = (() => {
     if (!status?.unlocked || !scanProgress) return null;
@@ -1352,17 +1574,24 @@ export function App() {
 
       {status?.unlocked && scanProgress?.status === "scanning" && (
         <div className="mx-3 mt-2 rounded border border-amber-500/35 bg-amber-500/10 px-3 py-2 text-xs text-amber-100">
+          <div className="mb-1.5 h-1.5 w-full overflow-hidden rounded bg-black/25">
+            <div
+              className="h-full bg-amber-400 transition-all duration-300"
+              style={{
+                width: `${Math.max(2, scanPercentDisplay(scanProgress))}%`
+              }}
+            />
+          </div>
           <span className="font-medium">
-            Auto-sync: ON
+            Syncing {scanPercentDisplay(scanProgress)}%
             {autoSyncHeights
-              ? ` (${autoSyncHeights.synced.toLocaleString()}/${autoSyncHeights.tip.toLocaleString()})`
+              ? ` · ${autoSyncHeights.synced.toLocaleString()}/${autoSyncHeights.tip.toLocaleString()} blocks`
               : ""}
           </span>{" "}
-          {Math.min(100, Math.max(0, Number(scanProgress.percent ?? 0))).toFixed(2)}% ·{" "}
-          {(scanProgress.scannedBlocks ?? 0).toLocaleString()}/{(scanProgress.totalBlocks ?? 0).toLocaleString()} blocks ·{" "}
-          {scanProgress.discoveredNotes ?? 0} notes
+          · {(scanProgress.scannedBlocks ?? 0).toLocaleString()}/
+          {(scanProgress.totalBlocks ?? 0).toLocaleString()} · {scanProgress.discoveredNotes ?? 0} notes
           <span className="mt-1 block text-[10px] leading-snug text-white/45">
-            Runs in the background while the wallet stays unlocked — switch tabs freely.
+            Keeps running in the background — switch tabs or close this popup until sync finishes.
           </span>
         </div>
       )}
@@ -1388,17 +1617,21 @@ export function App() {
             await extensionApi.walletRetryBroadcast(id);
             await refresh();
           }}
+          onSpeedUp={async (id) => {
+            await extensionApi.walletSpeedUp(id);
+            await refresh();
+          }}
         />
       )}
       {view === "send" && <SendView />}
       {view === "receive" && <ReceiveView status={status} />}
-      {view === "scan" && (
-        <ScanView status={status} scan={scanProgress} onWalletMetaChanged={() => void refresh()} />
-      )}
-      {view === "companion" && <CompanionView />}
       {view === "settings" && (
         <SettingsView
           endpoint={endpoint}
+          status={status}
+          scan={scanProgress}
+          onWalletMetaChanged={() => void refresh()}
+          onScanProgress={setScanProgress}
           onEndpointChange={async (url) => {
             await extensionApi.rpcSetEndpoint(url);
             await refresh();

--- a/browser-extension/wasm-core/popup/src/lib/extensionApi.ts
+++ b/browser-extension/wasm-core/popup/src/lib/extensionApi.ts
@@ -20,7 +20,7 @@ export type WalletStatus = {
 export type TxStateEntry = {
   id: string;
   txid: string | null;
-  state: "built" | "broadcast" | "pending" | "confirmed" | "failed";
+  state: "built" | "broadcast" | "pending" | "confirmed" | "failed" | "expired";
   origin: string;
   recipientAddress: string;
   amount: number;
@@ -33,6 +33,9 @@ export type TxStateEntry = {
   rawTxHex?: string | null;
   inputsUsed?: number;
   inputMode?: "single" | "multi" | string;
+  expiryHeight?: number | null;
+  priority?: boolean;
+  speedUpOf?: string | null;
 };
 
 export type PendingApproval = {
@@ -50,6 +53,8 @@ export type WalletScanProgressResult = {
   scannedBlocks?: number;
   totalBlocks?: number;
   percent?: number;
+  /** Integer 0–100 for stepped progress display. */
+  percentInt?: number;
   discoveredNotes?: number;
   totalBalanceZats?: number;
   scanError?: string | null;
@@ -162,9 +167,21 @@ export const extensionApi = {
     sendMessage<{ txs: TxStateEntry[]; updatedAt: number }>({ method: "wallet_get_transactions" }),
   walletRetryBroadcast: (id: string) =>
     sendMessage<{ txid: string }>({ method: "wallet_retry_broadcast", params: { id } }),
+  walletSpeedUp: (id: string, opts?: { companionPassword?: string }) =>
+    sendMessage<{ txid: string }>({
+      method: "wallet_speed_up",
+      params: { id, companionPassword: opts?.companionPassword, allowWasmFallback: true }
+    }),
   rpcSetEndpoint: (url: string) =>
     sendMessage<{ rpcEndpoint: string }>({
       method: "rpc_set_endpoint",
+      params: { url }
+    }),
+  rpcAutodetect: () =>
+    sendMessage<{ rpcEndpoint: string; blockCount: number }>({ method: "rpc_autodetect" }),
+  rpcProbeEndpoint: (url: string) =>
+    sendMessage<{ endpoint: string; connected: boolean }>({
+      method: "rpc_probe_endpoint",
       params: { url }
     }),
   rpcGetStatus: () =>
@@ -208,6 +225,7 @@ export const extensionApi = {
       startHeight: number;
       endHeight: number;
       status: string;
+      rpcEndpoint?: string;
     }>({ method: "wallet_start_scan", params });
   },
   walletScanProgress: () =>
@@ -216,6 +234,15 @@ export const extensionApi = {
     sendMessage<{ status: string }>({ method: "wallet_stop_scan" }),
   rpcSendRawTx: (rawTxHex: string) =>
     sendMessage<string>({ method: "rpc_send_raw_tx", params: { rawTxHex } }),
+  walletEstimateSendFee: (params?: { memo?: string; priority?: boolean }) =>
+    sendMessage<{
+      fee: number;
+      expiry_delta_blocks: number;
+      core_version: string;
+    }>({
+      method: "wallet_estimate_send_fee",
+      params: params ?? {}
+    }),
   walletProveTransaction: (tx: Record<string, unknown>) =>
     sendMessage<{
       txid: string;
@@ -326,7 +353,15 @@ export const extensionApi = {
 
 const STORAGE_COMPANION_BASE = "nozy_companion_base_url";
 const STORAGE_LWD_URL = "nozy_lightwalletd_url";
-const DEFAULT_TESTNET_LWD_URL = "https://testnet.zec.rocks:443/";
+const DEFAULT_LWD_URL = "http://127.0.0.1:9067";
+
+function normalizeStoredLwdUrl(raw: string): string {
+  const s = String(raw ?? "").trim();
+  if (!s || /zec\.rocks/i.test(s)) {
+    return DEFAULT_LWD_URL;
+  }
+  return s;
+}
 
 /** Local Nozy API + optional lightwalletd URL (popup chrome.storage; not sent to sites). */
 export async function getCompanionPrefs(): Promise<{ baseUrl: string; lightwalletdUrl: string }> {
@@ -334,7 +369,7 @@ export async function getCompanionPrefs(): Promise<{ baseUrl: string; lightwalle
     chrome.storage.local.get(
       {
         [STORAGE_COMPANION_BASE]: "http://127.0.0.1:3000",
-        [STORAGE_LWD_URL]: DEFAULT_TESTNET_LWD_URL
+        [STORAGE_LWD_URL]: DEFAULT_LWD_URL
       },
       (items) => {
         if (chrome.runtime.lastError) {
@@ -343,7 +378,7 @@ export async function getCompanionPrefs(): Promise<{ baseUrl: string; lightwalle
         }
         resolve({
           baseUrl: String(items[STORAGE_COMPANION_BASE]),
-          lightwalletdUrl: String(items[STORAGE_LWD_URL] ?? "")
+          lightwalletdUrl: normalizeStoredLwdUrl(String(items[STORAGE_LWD_URL] ?? ""))
         });
       }
     );
@@ -361,7 +396,7 @@ export async function setCompanionPrefs(prefs: {
       patch[STORAGE_COMPANION_BASE] = u || "http://127.0.0.1:3000";
     }
     if (prefs.lightwalletdUrl !== undefined) {
-      patch[STORAGE_LWD_URL] = prefs.lightwalletdUrl.trim();
+      patch[STORAGE_LWD_URL] = normalizeStoredLwdUrl(prefs.lightwalletdUrl);
     }
     chrome.storage.local.set(patch, () => {
       if (chrome.runtime.lastError) {

--- a/desktop-client/src-tauri/src/commands/transaction.rs
+++ b/desktop-client/src-tauri/src/commands/transaction.rs
@@ -40,6 +40,7 @@ fn tx_record_json(tx: &SentTransactionRecord) -> serde_json::Value {
         "timestamp": tx.created_at.timestamp(),
         "broadcast": tx.broadcast_at.is_some(),
         "spent_note_ids": tx.spent_note_ids,
+        "speed_up_of_txid": tx.speed_up_of_txid,
     })
 }
 
@@ -235,4 +236,95 @@ pub async fn get_transaction(txid: String) -> Result<serde_json::Value, TauriErr
         })?;
 
     Ok(tx_record_json(&transaction))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SpeedUpTransactionRequest {
+    pub original_txid: String,
+    pub password: Option<String>,
+    pub zebra_url: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SpeedUpTransactionResponse {
+    pub success: bool,
+    pub txid: Option<String>,
+    pub original_txid: String,
+    pub message: String,
+}
+
+#[command]
+pub async fn speed_up_transaction(
+    request: SpeedUpTransactionRequest,
+) -> Result<SpeedUpTransactionResponse, TauriError> {
+    let config = load_config();
+    let zebra_url = request
+        .zebra_url
+        .unwrap_or_else(|| config.zebra_url.clone());
+
+    let storage = WalletStorage::with_xdg_dir();
+    let password = request.password.as_deref().unwrap_or("");
+
+    let wallet = storage
+        .load_wallet(password)
+        .await
+        .map_err(|e| TauriError {
+            message: format!("Failed to load wallet: {}", e),
+            code: Some("WALLET_NOT_FOUND".to_string()),
+        })?;
+
+    match nozy::speed_up_transaction(wallet, &zebra_url, &request.original_txid).await {
+        Ok(new_txid) => Ok(SpeedUpTransactionResponse {
+            success: true,
+            txid: Some(new_txid.clone()),
+            original_txid: request.original_txid.clone(),
+            message: format!(
+                "Speed-up transaction broadcast. New TXID: {} (replaces {})",
+                new_txid, request.original_txid
+            ),
+        }),
+        Err(e) => Ok(SpeedUpTransactionResponse {
+            success: false,
+            txid: None,
+            original_txid: request.original_txid.clone(),
+            message: e.to_string(),
+        }),
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct CheckConfirmationsResponse {
+    pub pending_updated: usize,
+    pub expired_updated: usize,
+    pub confirmations_updated: usize,
+}
+
+#[command]
+pub async fn check_transaction_confirmations(
+    zebra_url: Option<String>,
+) -> Result<CheckConfirmationsResponse, TauriError> {
+    let config = load_config();
+    let zebra_url = zebra_url.unwrap_or_else(|| config.zebra_url.clone());
+    let zebra_client = ZebraClient::new(zebra_url);
+
+    let tx_storage = SentTransactionStorage::new().map_err(|e| TauriError::from(e.to_string()))?;
+
+    let pending_updated = tx_storage
+        .check_all_pending_transactions(&zebra_client)
+        .await
+        .unwrap_or(0);
+    let expired_updated = tx_storage
+        .check_expired_pending_transactions(&zebra_client)
+        .await
+        .unwrap_or(0);
+    let confirmations_updated = tx_storage
+        .update_confirmations(&zebra_client)
+        .await
+        .unwrap_or(0);
+
+    Ok(CheckConfirmationsResponse {
+        pending_updated,
+        expired_updated,
+        confirmations_updated,
+    })
 }

--- a/desktop-client/src-tauri/src/main.rs
+++ b/desktop-client/src-tauri/src/main.rs
@@ -30,6 +30,8 @@ fn main() {
             estimate_fee,
             get_transaction_history,
             get_transaction,
+            speed_up_transaction,
+            check_transaction_confirmations,
             get_config,
             set_zebra_url,
             test_zebra_connection,

--- a/desktop-client/src/lib/api.ts
+++ b/desktop-client/src/lib/api.ts
@@ -113,6 +113,37 @@ export const walletApi = {
     return { data: result };
   },
 
+  checkTransactionConfirmations: async (zebraUrl?: string): Promise<{
+    data: { pending_updated: number; expired_updated: number; confirmations_updated: number };
+  }> => {
+    const result = await invoke<{
+      pending_updated: number;
+      expired_updated: number;
+      confirmations_updated: number;
+    }>("check_transaction_confirmations", { zebraUrl: zebraUrl ?? null });
+    return { data: result };
+  },
+
+  speedUpTransaction: async (opts: {
+    originalTxid: string;
+    password?: string;
+    zebraUrl?: string;
+  }): Promise<{ data: { success: boolean; txid?: string; original_txid: string; message: string } }> => {
+    const result = await invoke<{
+      success: boolean;
+      txid?: string;
+      original_txid: string;
+      message: string;
+    }>("speed_up_transaction", {
+      request: {
+        original_txid: opts.originalTxid,
+        password: opts.password ?? "",
+        zebra_url: opts.zebraUrl ?? null,
+      },
+    });
+    return { data: result };
+  },
+
   getConfig: async (): Promise<{ data: ConfigResponse }> => {
     const result = await invoke<ConfigResponse>("get_config");
     return { data: result };

--- a/desktop-client/src/pages/History.tsx
+++ b/desktop-client/src/pages/History.tsx
@@ -32,7 +32,8 @@ function normalizeTx(raw: any): HistoryTx {
   const status =
     statusRaw === "confirmed" ||
     statusRaw === "pending" ||
-    statusRaw === "failed"
+    statusRaw === "failed" ||
+    statusRaw === "expired"
       ? statusRaw
       : statusRaw;
   const dateRaw = raw.broadcast_at ?? raw.created_at ?? raw.date ?? raw.block_time;
@@ -59,7 +60,7 @@ function normalizeTx(raw: any): HistoryTx {
 }
 
 type FilterType = "all" | "sent" | "received";
-type FilterStatus = "all" | "confirmed" | "pending" | "failed";
+type FilterStatus = "all" | "confirmed" | "pending" | "failed" | "expired";
 type FilterDateRange = "all" | "7" | "30" | "90";
 
 function filterAndSortTxs(
@@ -147,6 +148,8 @@ export function HistoryPage() {
   const [saveContactName, setSaveContactName] = useState("");
   const [saveContactNotes, setSaveContactNotes] = useState("");
   const [saveContactSaving, setSaveContactSaving] = useState(false);
+  const [speedUpPassword, setSpeedUpPassword] = useState("");
+  const [speedUpBusy, setSpeedUpBusy] = useState(false);
 
   const {
     showFiatEquivalent,
@@ -155,14 +158,14 @@ export function HistoryPage() {
     customFiatPerZec,
   } = useSettingsStore();
 
-  useEffect(() => {
-    let cancelled = false;
+  const loadHistory = () => {
     setLoading(true);
     setError(null);
-    walletApi
-      .getTransactionHistory()
+    return walletApi
+      .checkTransactionConfirmations()
+      .catch(() => ({ data: { pending_updated: 0, expired_updated: 0, confirmations_updated: 0 } }))
+      .then(() => walletApi.getTransactionHistory())
       .then((res) => {
-        if (cancelled) return;
         const raw = res?.data;
         if (Array.isArray(raw)) {
           const normalized = raw.map(normalizeTx).filter((t) => t.id);
@@ -172,14 +175,17 @@ export function HistoryPage() {
         }
       })
       .catch((e) => {
-        if (!cancelled) {
-          setError(formatErrorForDisplay(e, "Failed to load transaction history"));
-          setTxs([]);
-        }
+        setError(formatErrorForDisplay(e, "Failed to load transaction history"));
+        setTxs([]);
       })
-      .finally(() => {
-        if (!cancelled) setLoading(false);
-      });
+      .finally(() => setLoading(false));
+  };
+
+  useEffect(() => {
+    let cancelled = false;
+    loadHistory().then(() => {
+      if (cancelled) return;
+    });
     return () => {
       cancelled = true;
     };
@@ -240,6 +246,33 @@ export function HistoryPage() {
     const fiat = amountZec * effectiveFiatRate;
     return formatFiatAmount(fiat, fiatCurrency);
   }
+
+  const handleSpeedUp = async () => {
+    if (!selectedTx) return;
+    if (!speedUpPassword.trim()) {
+      toast.error("Enter your wallet password to speed up");
+      return;
+    }
+    setSpeedUpBusy(true);
+    try {
+      const { data } = await walletApi.speedUpTransaction({
+        originalTxid: selectedTx.id,
+        password: speedUpPassword,
+      });
+      if (!data.success) {
+        toast.error(data.message || "Speed-up failed");
+        return;
+      }
+      toast.success(data.message || "Speed-up transaction broadcast");
+      setSpeedUpPassword("");
+      setSelectedTx(null);
+      await loadHistory();
+    } catch (e) {
+      toast.error(formatErrorForDisplay(e, "Speed-up failed"));
+    } finally {
+      setSpeedUpBusy(false);
+    }
+  };
 
   const handleSaveToContacts = async () => {
     if (!selectedTx) return;
@@ -312,6 +345,7 @@ export function HistoryPage() {
               <option value="confirmed">Confirmed</option>
               <option value="pending">Pending</option>
               <option value="failed">Failed</option>
+              <option value="expired">Expired</option>
             </select>
             <select
               value={filterDateRange}
@@ -435,7 +469,9 @@ export function HistoryPage() {
                         : tx.status === "pending"
                           ? "bg-yellow-100 text-yellow-700"
                           : tx.status === "failed"
-                            ? "bg-red-100 text-red-700"
+                          ? "bg-red-100 text-red-700"
+                          : tx.status === "expired"
+                            ? "bg-orange-100 text-orange-700"
                             : "bg-gray-100 text-gray-700"
                     }`}
                   >
@@ -506,6 +542,27 @@ export function HistoryPage() {
                 {detailExtra.broadcast_at && (
                   <DetailRow label="Broadcast at" value={formatDetailDate(detailExtra.broadcast_at)} />
                 )}
+              </div>
+            )}
+            {selectedTx.type === "sent" && selectedTx.status === "expired" && (
+              <div className="pt-4 mt-2 border-t border-gray-200 space-y-3">
+                <p className="text-sm text-gray-600">
+                  This transaction expired unmined. Speed up rebuilds a new transaction at priority fee (×4).
+                </p>
+                <Input
+                  type="password"
+                  label="Wallet password"
+                  placeholder="Required to sign the new transaction"
+                  value={speedUpPassword}
+                  onChange={(e) => setSpeedUpPassword(e.target.value)}
+                />
+                <Button
+                  onClick={handleSpeedUp}
+                  disabled={speedUpBusy || !speedUpPassword.trim()}
+                  className="w-full"
+                >
+                  {speedUpBusy ? "Building priority transaction…" : "Speed up (priority fee ×4)"}
+                </Button>
               </div>
             )}
           </div>


### PR DESCRIPTION
## Summary
- **Desktop:** History page refreshes confirmations/expiry on load, shows **Expired** filter/status, and **Speed up (priority fee ×4)** in transaction details (password required).
- **Extension:** Pending pilot txs auto-mark **expired** when chain tip passes `expiryHeight`; dashboard shows **Speed up** instead of rebroadcasting the same raw tx. Rebuilds via WASM at priority fee; optional companion `/api/transaction/speed-up` when `companionPassword` is passed.

## Depends on
- Merged #75 (core `nozy::tx_lifecycle` + api-server speed-up endpoint)

## Test plan
- [ ] Desktop: send with short expiry, wait past expiry, open History → status **expired** → Speed up → new txid
- [ ] Extension: send via dApp approval, let tx expire unmined → Dashboard shows **Speed up** → new tx broadcasts
- [ ] `node --test browser-extension/background/tx-lifecycle.test.mjs`
- [ ] `cargo check` in `desktop-client/src-tauri`

Made with [Cursor](https://cursor.com)