### PR TITLE
fix(api): structured /api/sync errors and quieter Orchard scan logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@
 
 - **Extension:** `wallet_retry_broadcast` kept for failed pre-broadcast retries only; expired txs use `wallet_speed_up`.
 
+### Changed
+
+- **`/api/sync` errors:** structured JSON (`phase`, `block_height`, `scan_start`/`scan_end`, `code`) instead of opaque HTTP 500; Zebra outages return **503** `ZEBRA_UNAVAILABLE`.
+- **Orchard scan logging:** per-action decrypt chatter is quiet by default; set `NOZY_VERBOSE_SCAN=1` or `RUST_LOG=nozy::notes=debug` for detail. API/non-TTY builds skip indicatif progress spam.
+
 ### Fixed
 
 - **`/api/sync` repeat calls:** when already caught up to chain tip, return cached balance without rescanning; serialize concurrent syncs; richer sync response (`balance_zatoshis`, `already_synced`, `total_notes`).

--- a/api-server/src/handlers.rs
+++ b/api-server/src/handlers.rs
@@ -452,8 +452,8 @@ pub async fn sync_wallet(
             }))
         }
         Err(e) => {
-            let status =
-                StatusCode::from_u16(e.api_status_code()).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+            let status = StatusCode::from_u16(e.api_status_code())
+                .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
             Err((status, ResponseJson(e.to_api_json())))
         }
     }

--- a/api-server/src/handlers.rs
+++ b/api-server/src/handlers.rs
@@ -451,12 +451,11 @@ pub async fn sync_wallet(
                 message,
             }))
         }
-        Err(e) => Err((
-            StatusCode::INTERNAL_SERVER_ERROR,
-            ResponseJson(serde_json::json!({
-                "error": format!("Sync failed: {}", e)
-            })),
-        )),
+        Err(e) => {
+            let status =
+                StatusCode::from_u16(e.api_status_code()).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+            Err((status, ResponseJson(e.to_api_json())))
+        }
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -35,6 +35,9 @@ pub enum NozyError {
     #[error("Note scanning error: {0}")]
     NoteScanning(String),
 
+    #[error("Orchard scan failed at block {height}: {detail}")]
+    ScanAtBlock { height: u32, detail: String },
+
     #[error("RPC error: {0}")]
     Rpc(String),
 
@@ -76,6 +79,10 @@ impl NozyError {
             NozyError::NoteScanning(msg) => {
                 NozyError::NoteScanning(format!("{}: {}", context, msg))
             }
+            NozyError::ScanAtBlock { height, detail } => NozyError::ScanAtBlock {
+                height,
+                detail: format!("{}: {}", context, detail),
+            },
             NozyError::Rpc(msg) => NozyError::Rpc(format!("{}: {}", context, msg)),
             NozyError::Cryptographic(msg) => {
                 NozyError::Cryptographic(format!("{}: {}", context, msg))
@@ -86,6 +93,14 @@ impl NozyError {
             NozyError::InvalidInput(msg) => {
                 NozyError::InvalidInput(format!("{}: {}", context, msg))
             }
+        }
+    }
+
+    /// Block height when a scan failed mid-range (`ScanAtBlock` only).
+    pub fn scan_block_height(&self) -> Option<u32> {
+        match self {
+            NozyError::ScanAtBlock { height, .. } => Some(*height),
+            _ => None,
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,6 +68,8 @@ pub mod progress;
 pub mod proving;
 #[cfg(feature = "native")]
 pub mod rpc_test;
+#[cfg(feature = "native")]
+pub mod scan_log;
 #[cfg(feature = "secret-network")]
 pub mod secret;
 #[cfg(feature = "native")]
@@ -183,8 +185,8 @@ pub use transaction_history::{
 pub use tx_lifecycle::{expire_stale_pending_transactions, speed_up_transaction};
 #[cfg(feature = "native")]
 pub use wallet_sync::{
-    resolve_scan_range, sync_wallet_notes, ScanRange, WalletSyncOptions, WalletSyncResult,
-    DEFAULT_INCREMENTAL_BATCH, MAINNET_DEFAULT_SCAN_START,
+    resolve_scan_range, sync_wallet_notes, ScanRange, WalletSyncError, WalletSyncOptions,
+    WalletSyncPhase, WalletSyncResult, DEFAULT_INCREMENTAL_BATCH, MAINNET_DEFAULT_SCAN_START,
 };
 #[cfg(feature = "native")]
 pub use zeaking::{IndexStats, IndexedBlock, IndexedTransaction, Zeaking};

--- a/src/note_sync.rs
+++ b/src/note_sync.rs
@@ -1,4 +1,4 @@
-use crate::error::NozyResult;
+use crate::error::{NozyError, NozyResult};
 use crate::hd_wallet::HDWallet;
 use crate::wallet_sync::{sync_wallet_notes, WalletSyncOptions, WalletSyncResult};
 use crate::zebra_integration::ZebraClient;
@@ -21,7 +21,8 @@ impl NoteSyncManager {
 
     pub async fn sync_once(&self) -> NozyResult<SyncResult> {
         let options = WalletSyncOptions::api_default();
-        let result = sync_wallet_notes(self.wallet.clone(), options).await?;
+        let result = sync_wallet_notes(self.wallet.clone(), options).await
+            .map_err(|e| NozyError::NoteScanning(e.message))?;
 
         Ok(SyncResult {
             notes_found: result.new_notes_in_scan,

--- a/src/note_sync.rs
+++ b/src/note_sync.rs
@@ -21,7 +21,8 @@ impl NoteSyncManager {
 
     pub async fn sync_once(&self) -> NozyResult<SyncResult> {
         let options = WalletSyncOptions::api_default();
-        let result = sync_wallet_notes(self.wallet.clone(), options).await
+        let result = sync_wallet_notes(self.wallet.clone(), options)
+            .await
             .map_err(|e| NozyError::NoteScanning(e.message))?;
 
         Ok(SyncResult {

--- a/src/notes.rs
+++ b/src/notes.rs
@@ -8,6 +8,8 @@ use crate::note_index::NoteIndex;
 use crate::orchard_tree_codec::orchard_commitment_tree_from_final_state;
 use crate::orchard_tree_codec::OrchardCommitmentTree;
 use crate::orchard_witness::{merkle_hash_from_cmx_bytes, OrchardWitnessTracker};
+use crate::scan_log;
+use crate::scan_verbose;
 use crate::zebra_integration::ZebraClient;
 use futures::future::join_all;
 use indicatif::{ProgressBar, ProgressStyle};
@@ -397,19 +399,33 @@ impl NoteScanner {
         let start_height = start_height.min(end_height);
 
         let total_blocks = (end_height - start_height + 1) as u64;
-        println!(
-            "Scanning blocks {} to {} for Orchard notes... ({} blocks)",
-            start_height, end_height, total_blocks
-        );
+        if scan_log::scan_progress_enabled() {
+            println!(
+                "Scanning blocks {} to {} for Orchard notes... ({} blocks)",
+                start_height, end_height, total_blocks
+            );
+        } else {
+            tracing::info!(
+                start_height,
+                end_height,
+                total_blocks,
+                "Scanning Orchard notes"
+            );
+        }
 
-        let pb = ProgressBar::new(total_blocks);
-        pb.set_style(
-            ProgressStyle::default_bar()
-                .template("{spinner:.green} [{elapsed_precise}] [{wide_bar:.cyan/blue}] {pos}/{len} blocks ({percent}%) | {msg}")
-                .unwrap_or_else(|_| ProgressStyle::default_bar())
-                .progress_chars("#>-")
-        );
-        pb.set_message("Scanning blocks...");
+        let pb = if scan_log::scan_progress_enabled() {
+            let pb = ProgressBar::new(total_blocks);
+            pb.set_style(
+                ProgressStyle::default_bar()
+                    .template("{spinner:.green} [{elapsed_precise}] [{wide_bar:.cyan/blue}] {pos}/{len} blocks ({percent}%) | {msg}")
+                    .unwrap_or_else(|_| ProgressStyle::default_bar())
+                    .progress_chars("#>-"),
+            );
+            pb.set_message("Scanning blocks...");
+            pb
+        } else {
+            ProgressBar::hidden()
+        };
 
         let account_id = AccountId::try_from(0)
             .map_err(|e| NozyError::KeyDerivation(format!("Invalid account ID: {:?}", e)))?;
@@ -429,9 +445,11 @@ impl NoteScanner {
 
         zeroize_bytes(&mut seed_bytes);
 
-        pb.println(
-            "🔑 Generated scanning keys from wallet mnemonic (Orchard only; External and Internal scopes)",
-        );
+        if scan_log::scan_progress_enabled() {
+            pb.println(
+                "Generated scanning keys from wallet mnemonic (Orchard only; External and Internal scopes)",
+            );
+        }
 
         let mut note_index = self.note_index.take().unwrap_or_else(NoteIndex::new);
         let mut all_notes = Vec::new();
@@ -544,17 +562,17 @@ impl NoteScanner {
                             &mut spendable_notes,
                             &pb,
                         ) {
-                            return Err(NozyError::InvalidOperation(format!(
-                                "Orchard scan failed at block {}: {}",
-                                height, e
-                            )));
+                            return Err(NozyError::ScanAtBlock {
+                                height,
+                                detail: e.to_string(),
+                            });
                         }
                     }
                     Err(e) => {
-                        return Err(NozyError::NetworkError(format!(
-                            "Failed to fetch block {} while scanning notes: {}",
-                            height, e
-                        )));
+                        return Err(NozyError::ScanAtBlock {
+                            height,
+                            detail: format!("Failed to fetch block while scanning notes: {}", e),
+                        });
                     }
                 }
 
@@ -583,7 +601,9 @@ impl NoteScanner {
                 .unwrap_or(!sn.orchard_note.spent)
         });
 
-        pb.finish_with_message("Scanning complete!");
+        if scan_log::scan_progress_enabled() {
+            pb.finish_with_message("Scanning complete!");
+        }
 
         let total_balance = note_index.total_balance();
         let unspent_count = note_index.unspent_count();
@@ -600,12 +620,21 @@ impl NoteScanner {
             spendable_count,
         };
 
-        println!(
-            "Scan complete: Orchard {} notes ({} spendable, {} ZAT)",
-            result.notes.len(),
-            spendable_count,
-            total_balance
-        );
+        if scan_log::scan_progress_enabled() {
+            println!(
+                "Scan complete: Orchard {} notes ({} spendable, {} ZAT)",
+                result.notes.len(),
+                spendable_count,
+                total_balance
+            );
+        } else {
+            tracing::info!(
+                notes = result.notes.len(),
+                spendable = spendable_count,
+                balance_zat = total_balance,
+                "Orchard scan complete"
+            );
+        }
 
         Ok((result, spendable_notes))
     }
@@ -668,10 +697,18 @@ impl NoteScanner {
                         tr.register_discovered_note(orchard_note.nullifier.to_bytes())?;
                     }
 
-                    pb.println(format!(
-                        "🎉 Found note in block {} (scope: {:?})",
-                        block_height, scope
-                    ));
+                    if scan_log::scan_progress_enabled() {
+                        pb.println(format!(
+                            "Found note in block {} (scope: {:?})",
+                            block_height, scope
+                        ));
+                    } else {
+                        tracing::info!(
+                            block_height,
+                            ?scope,
+                            "Found Orchard note"
+                        );
+                    }
 
                     let nf = orchard_note.nullifier.to_bytes();
                     let witness_hex = if let Some(t) = witness_tracker.as_ref() {
@@ -720,16 +757,17 @@ impl NoteScanner {
         };
         use zcash_note_encryption::EphemeralKeyBytes;
 
-        println!(
-            "🔍 Attempting REAL Orchard action decryption in transaction {} (scope: {:?})",
-            txid, scope
+        scan_verbose!(
+            "Attempting Orchard action decryption in transaction {} (scope: {:?})",
+            txid,
+            scope
         );
 
         let nullifier_result = Nullifier::from_bytes(&action.nullifier);
         let nullifier = match nullifier_result.into_option() {
             Some(n) => n,
             None => {
-                println!("⚠️  Invalid nullifier bytes");
+                scan_verbose!("Invalid nullifier bytes");
                 return Ok(None);
             }
         };
@@ -738,7 +776,7 @@ impl NoteScanner {
         let cmx = match cmx_result.into_option() {
             Some(c) => c,
             None => {
-                println!("⚠️  Invalid cmx bytes");
+                scan_verbose!("Invalid cmx bytes");
                 return Ok(None);
             }
         };
@@ -749,19 +787,18 @@ impl NoteScanner {
         if action.encrypted_note.len() >= 52 {
             compact_enc_ciphertext.copy_from_slice(&action.encrypted_note[..52]);
         } else {
-            println!("⚠️  Encrypted note too short for CompactAction");
+            scan_verbose!("Encrypted note too short for CompactAction");
             return Ok(None);
         }
 
-        println!("✅ **REAL NOTE DECRYPTION FRAMEWORK OPERATIONAL!**");
-        println!("   Successfully parsed ALL Action components from blockchain:");
-        println!("   Nullifier: {}", hex::encode(&action.nullifier));
-        println!("   CMX: {}", hex::encode(&action.cmx));
-        println!("   CV: {}", hex::encode(&action.cv));
-        println!("   RK: {}", hex::encode(&action.rk));
-        println!("   Ephemeral Key: {}", hex::encode(&action.ephemeral_key));
-        println!("   Encrypted Note: {} bytes", action.encrypted_note.len());
-        println!("   Out Ciphertext: {} bytes", action.enc_ciphertext.len());
+        scan_verbose!("Parsed Orchard action components from blockchain");
+        scan_verbose!("   Nullifier: {}", hex::encode(&action.nullifier));
+        scan_verbose!("   CMX: {}", hex::encode(&action.cmx));
+        scan_verbose!("   CV: {}", hex::encode(&action.cv));
+        scan_verbose!("   RK: {}", hex::encode(&action.rk));
+        scan_verbose!("   Ephemeral Key: {}", hex::encode(&action.ephemeral_key));
+        scan_verbose!("   Encrypted Note: {} bytes", action.encrypted_note.len());
+        scan_verbose!("   Out Ciphertext: {} bytes", action.enc_ciphertext.len());
 
         let compact_action =
             CompactAction::from_parts(nullifier, cmx, ephemeral_key, compact_enc_ciphertext);
@@ -770,32 +807,12 @@ impl NoteScanner {
 
         let prepared_ivk = PreparedIncomingViewingKey::new(ivk);
 
-        println!("🔧 **COMPLETE DECRYPTION FRAMEWORK READY:**");
-        println!("   ✅ Real Zebra RPC integration");
-        println!("   ✅ Real Orchard action parsing");
-        println!("   ✅ Real cryptographic key generation");
-        println!("   ✅ Real zcash_note_encryption library integration");
-        println!("   ✅ Real CompactAction construction");
-        println!("   ✅ Real OrchardDomain creation");
-        println!("   ✅ Real PreparedIncomingViewingKey");
-
-        println!("🎉 **COMPLETE NOTE DECRYPTION IMPLEMENTED!**");
-        println!("   ✅ Real Nullifier parsed and validated");
-        println!("   ✅ Real ExtractedNoteCommitment constructed");
-        println!("   ✅ Real EphemeralKeyBytes created");
-        println!("   ✅ Real CompactAction constructed from blockchain data");
-        println!("   ✅ Real OrchardDomain created for decryption");
-        println!("   ✅ Real PreparedIncomingViewingKey prepared");
-        println!("   ✅ Using official zcash_note_encryption library");
-
-        println!("💡 **NOTE DECRYPTION STATUS: FULLY IMPLEMENTED**");
-        println!("   All cryptographic components working with real blockchain data!");
-        println!("   Ready to detect and decrypt your ZEC when present!");
+        scan_verbose!("Orchard decryption framework ready (CompactAction + OrchardDomain + IVK)");
 
         match try_compact_note_decryption(&domain, &prepared_ivk, &compact_action) {
             Some((note, address)) => {
-                println!(
-                    "✅ Successfully decrypted note: {} ZAT",
+                scan_verbose!(
+                    "Successfully decrypted note: {} ZAT",
                     note.value().inner()
                 );
 
@@ -891,7 +908,7 @@ impl NoteScanner {
         let mut actions = Vec::new();
 
         if let Some(actions_array) = orchard_json["actions"].as_array() {
-            println!("📋 Found {} Orchard actions to parse", actions_array.len());
+            scan_verbose!("Found {} Orchard actions to parse", actions_array.len());
             for (idx, action) in actions_array.iter().enumerate() {
                 let nullifier_hex = action["nullifier"].as_str().unwrap_or("");
                 let cmx_hex = action["cmx"].as_str().unwrap_or("");
@@ -969,14 +986,21 @@ impl NoteScanner {
                     };
 
                     actions.push(action_data);
-                    println!("✅ Parsed action {} successfully", idx);
+                    scan_verbose!("Parsed action {} successfully", idx);
                 } else {
-                    eprintln!("⚠️  Skipping action {} with invalid field sizes", idx);
-                    eprintln!("    nullifier: {} bytes (expected 32), cmx: {} bytes (expected 32), ephemeral_key: {} bytes (expected 32)", 
-                             nullifier.len(), cmx.len(), ephemeral_key.len());
-                    eprintln!("    enc_ciphertext: {} bytes (expected >= 52), out_ciphertext: {} bytes (expected 80)", 
-                             enc_ciphertext.len(), out_ciphertext.len());
-                    eprintln!(
+                    scan_verbose!("Skipping action {} with invalid field sizes", idx);
+                    scan_verbose!(
+                        "    nullifier: {} bytes (expected 32), cmx: {} bytes (expected 32), ephemeral_key: {} bytes (expected 32)",
+                        nullifier.len(),
+                        cmx.len(),
+                        ephemeral_key.len()
+                    );
+                    scan_verbose!(
+                        "    enc_ciphertext: {} bytes (expected >= 52), out_ciphertext: {} bytes (expected 80)",
+                        enc_ciphertext.len(),
+                        out_ciphertext.len()
+                    );
+                    scan_verbose!(
                         "    cv: {} bytes (expected 32), rk: {} bytes (expected 32)",
                         cv.len(),
                         rk.len()
@@ -984,7 +1008,7 @@ impl NoteScanner {
                 }
             }
         } else {
-            println!("⚠️  No 'actions' array found in Orchard JSON");
+            scan_verbose!("No 'actions' array found in Orchard JSON");
         }
 
         Ok(actions)
@@ -1008,19 +1032,30 @@ pub async fn scan_real_notes(
     start_height: u32,
     end_height: u32,
 ) -> NozyResult<Vec<SpendableNote>> {
-    println!(
-        "🔍 Scanning blockchain for Orchard notes from height {} to {}",
-        start_height, end_height
-    );
+    if scan_log::scan_progress_enabled() {
+        println!(
+            "Scanning blockchain for Orchard notes from height {} to {}",
+            start_height, end_height
+        );
+    } else {
+        tracing::info!(start_height, end_height, "Scanning Orchard notes");
+    }
 
     let mut scanner = NoteScanner::new(wallet.clone(), zebra_client.clone());
     let (_, spendable_notes) = scanner
         .scan_notes(Some(start_height), Some(end_height))
         .await?;
 
-    println!(
-        "✅ Note scanning completed. Found {} spendable notes",
-        spendable_notes.len()
-    );
+    if scan_log::scan_progress_enabled() {
+        println!(
+            "Note scanning completed. Found {} spendable notes",
+            spendable_notes.len()
+        );
+    } else {
+        tracing::info!(
+            spendable = spendable_notes.len(),
+            "Orchard note scan completed"
+        );
+    }
     Ok(spendable_notes)
 }

--- a/src/notes.rs
+++ b/src/notes.rs
@@ -703,11 +703,7 @@ impl NoteScanner {
                             block_height, scope
                         ));
                     } else {
-                        tracing::info!(
-                            block_height,
-                            ?scope,
-                            "Found Orchard note"
-                        );
+                        tracing::info!(block_height, ?scope, "Found Orchard note");
                     }
 
                     let nf = orchard_note.nullifier.to_bytes();
@@ -811,10 +807,7 @@ impl NoteScanner {
 
         match try_compact_note_decryption(&domain, &prepared_ivk, &compact_action) {
             Some((note, address)) => {
-                scan_verbose!(
-                    "Successfully decrypted note: {} ZAT",
-                    note.value().inner()
-                );
+                scan_verbose!("Successfully decrypted note: {} ZAT", note.value().inner());
 
                 let canonical_nullifier = note.nullifier(orchard_fvk);
 

--- a/src/scan_log.rs
+++ b/src/scan_log.rs
@@ -1,0 +1,30 @@
+//! Scan/decrypt logging: quiet by default for API server and plain/CI output.
+//!
+//! Enable per-action decrypt chatter with `NOZY_VERBOSE_SCAN=1`, or use
+//! `RUST_LOG=nozy::notes=debug` for `tracing::debug` output without println spam.
+
+use std::io::IsTerminal;
+
+/// Verbose per-action decrypt logging (`NOZY_VERBOSE_SCAN=1`).
+pub fn verbose_scan_logging() -> bool {
+    std::env::var("NOZY_VERBOSE_SCAN").as_deref() == Ok("1")
+}
+
+/// Interactive indicatif progress bar (TTY and not plain output).
+pub fn scan_progress_enabled() -> bool {
+    if std::env::var("NOZY_PLAIN_OUTPUT").is_ok() {
+        return false;
+    }
+    std::io::stdout().is_terminal()
+}
+
+#[macro_export]
+macro_rules! scan_verbose {
+    ($($arg:tt)*) => {{
+        if $crate::scan_log::verbose_scan_logging() {
+            println!($($arg)*);
+        } else {
+            tracing::debug!($($arg)*);
+        }
+    }};
+}

--- a/src/wallet_sync.rs
+++ b/src/wallet_sync.rs
@@ -3,13 +3,145 @@
 //! See [`docs/rfcs/WALLET_SYNC_UNIFIED_ARCHITECTURE.md`](../docs/rfcs/WALLET_SYNC_UNIFIED_ARCHITECTURE.md).
 
 use crate::config::{load_config, update_last_scan_height, WalletConfig};
-use crate::error::{NozyError, NozyResult};
+use crate::error::NozyError;
 use crate::hd_wallet::HDWallet;
 use crate::notes::{
     load_wallet_notes, merge_scanned_notes, save_wallet_notes, wallet_unspent_balance_zatoshis,
     NoteScanner,
 };
 use crate::zebra_integration::ZebraClient;
+use serde::{Deserialize, Serialize};
+
+/// Phase of [`sync_wallet_notes`] where a failure occurred (for API integrators).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WalletSyncPhase {
+    Connect,
+    ResolveRange,
+    LoadNotes,
+    Scan,
+    Persist,
+    Checkpoint,
+}
+
+impl WalletSyncPhase {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Connect => "connect",
+            Self::ResolveRange => "resolve_range",
+            Self::LoadNotes => "load_notes",
+            Self::Scan => "scan",
+            Self::Persist => "persist",
+            Self::Checkpoint => "checkpoint",
+        }
+    }
+
+    fn error_code(self) -> &'static str {
+        match self {
+            Self::Connect => "SYNC_CONNECT_FAILED",
+            Self::ResolveRange => "SYNC_RANGE_FAILED",
+            Self::LoadNotes => "SYNC_LOAD_NOTES_FAILED",
+            Self::Scan => "SYNC_SCAN_FAILED",
+            Self::Persist => "SYNC_PERSIST_FAILED",
+            Self::Checkpoint => "SYNC_CHECKPOINT_FAILED",
+        }
+    }
+}
+
+/// Structured sync failure with scan context for HTTP clients.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WalletSyncError {
+    pub phase: WalletSyncPhase,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub block_height: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scan_start: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scan_end: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub chain_tip: Option<u32>,
+}
+
+impl WalletSyncError {
+    pub fn is_zebra_unavailable(&self) -> bool {
+        crate::cli_helpers::is_zebra_unavailable_error(&self.message)
+    }
+
+    pub fn api_status_code(&self) -> u16 {
+        if self.is_zebra_unavailable() {
+            503
+        } else {
+            500
+        }
+    }
+
+    pub fn api_code(&self) -> &str {
+        if self.is_zebra_unavailable() {
+            "ZEBRA_UNAVAILABLE"
+        } else {
+            self.phase.error_code()
+        }
+    }
+
+    pub fn to_api_json(&self) -> serde_json::Value {
+        serde_json::json!({
+            "error": self.message,
+            "code": self.api_code(),
+            "phase": self.phase.as_str(),
+            "block_height": self.block_height,
+            "scan_start": self.scan_start,
+            "scan_end": self.scan_end,
+            "chain_tip": self.chain_tip,
+        })
+    }
+
+    fn with_range(
+        phase: WalletSyncPhase,
+        source: NozyError,
+        block_height: Option<u32>,
+        scan_start: Option<u32>,
+        scan_end: Option<u32>,
+        chain_tip: Option<u32>,
+    ) -> Self {
+        Self {
+            phase,
+            message: source.to_string(),
+            block_height: block_height.or_else(|| source.scan_block_height()),
+            scan_start,
+            scan_end,
+            chain_tip,
+        }
+    }
+}
+
+impl std::fmt::Display for WalletSyncError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl std::error::Error for WalletSyncError {}
+
+struct SyncRangeContext {
+    scan_start: u32,
+    scan_end: u32,
+    chain_tip: u32,
+}
+
+impl SyncRangeContext {
+    fn from_range(range: &ScanRange) -> Self {
+        Self {
+            scan_start: range.scan_start,
+            scan_end: range.scan_end,
+            chain_tip: range.chain_tip,
+        }
+    }
+
+    fn scan_fields(&self) -> (Option<u32>, Option<u32>, Option<u32>) {
+        (Some(self.scan_start), Some(self.scan_end), Some(self.chain_tip))
+    }
+}
 
 /// Default Orchard-heavy mainnet scan floor when no `last_scan_height` exists.
 pub const MAINNET_DEFAULT_SCAN_START: u32 = 3_050_000;
@@ -117,17 +249,46 @@ pub fn resolve_scan_range(
 pub async fn sync_wallet_notes(
     wallet: HDWallet,
     options: WalletSyncOptions,
-) -> NozyResult<WalletSyncResult> {
+) -> Result<WalletSyncResult, WalletSyncError> {
     let mut config = load_config();
     if let Some(url) = options.zebra_url.clone() {
         config.zebra_url = url;
     }
 
     let zebra_client = ZebraClient::from_config(&config);
-    let chain_tip = zebra_client.get_block_count().await?;
-    let range = resolve_scan_range(&config, &options, chain_tip)?;
+    let chain_tip = zebra_client.get_block_count().await.map_err(|e| {
+        WalletSyncError::with_range(
+            WalletSyncPhase::Connect,
+            e,
+            None,
+            None,
+            None,
+            None,
+        )
+    })?;
+    let range = resolve_scan_range(&config, &options, chain_tip).map_err(|e| {
+        WalletSyncError::with_range(
+            WalletSyncPhase::ResolveRange,
+            e,
+            None,
+            None,
+            None,
+            Some(chain_tip),
+        )
+    })?;
+    let ctx = SyncRangeContext::from_range(&range);
+    let (scan_start, scan_end, chain_tip_opt) = ctx.scan_fields();
 
-    let notes_before = load_wallet_notes()?;
+    let notes_before = load_wallet_notes().map_err(|e| {
+        WalletSyncError::with_range(
+            WalletSyncPhase::LoadNotes,
+            e,
+            None,
+            scan_start,
+            scan_end,
+            chain_tip_opt,
+        )
+    })?;
     let total_before = notes_before.len();
     let balance_before = wallet_unspent_balance_zatoshis(&notes_before);
 
@@ -151,13 +312,41 @@ pub async fn sync_wallet_notes(
     let mut note_scanner = NoteScanner::new(wallet, zebra_client);
     let (scan_result, _spendable) = note_scanner
         .scan_notes(Some(range.scan_start), Some(range.scan_end))
-        .await?;
+        .await
+        .map_err(|e| {
+            WalletSyncError::with_range(
+                WalletSyncPhase::Scan,
+                e,
+                None,
+                scan_start,
+                scan_end,
+                chain_tip_opt,
+            )
+        })?;
 
     let mut cached_notes = notes_before;
     merge_scanned_notes(&mut cached_notes, &scan_result.notes);
-    save_wallet_notes(&cached_notes)?;
+    save_wallet_notes(&cached_notes).map_err(|e| {
+        WalletSyncError::with_range(
+            WalletSyncPhase::Persist,
+            e,
+            None,
+            scan_start,
+            scan_end,
+            chain_tip_opt,
+        )
+    })?;
 
-    update_last_scan_height(range.scan_end)?;
+    update_last_scan_height(range.scan_end).map_err(|e| {
+        WalletSyncError::with_range(
+            WalletSyncPhase::Checkpoint,
+            e,
+            None,
+            scan_start,
+            scan_end,
+            chain_tip_opt,
+        )
+    })?;
 
     let balance_zatoshis = wallet_unspent_balance_zatoshis(&cached_notes);
     let unspent_notes = cached_notes.iter().filter(|n| !n.spent).count();
@@ -225,6 +414,26 @@ mod tests {
         let opts = WalletSyncOptions::default();
         let range = resolve_scan_range(&config, &opts, 3_050_000).unwrap();
         assert!(range.scan_start > range.scan_end);
+    }
+
+    #[test]
+    fn scan_error_includes_block_height_in_api_json() {
+        let err = WalletSyncError::with_range(
+            WalletSyncPhase::Scan,
+            NozyError::ScanAtBlock {
+                height: 3_050_123,
+                detail: "witness append failed".to_string(),
+            },
+            None,
+            Some(3_050_000),
+            Some(3_051_000),
+            Some(3_060_000),
+        );
+        let json = err.to_api_json();
+        assert_eq!(json["phase"], "scan");
+        assert_eq!(json["block_height"], 3_050_123);
+        assert_eq!(json["code"], "SYNC_SCAN_FAILED");
+        assert_eq!(json["scan_start"], 3_050_000);
     }
 
     #[test]

--- a/src/wallet_sync.rs
+++ b/src/wallet_sync.rs
@@ -139,7 +139,11 @@ impl SyncRangeContext {
     }
 
     fn scan_fields(&self) -> (Option<u32>, Option<u32>, Option<u32>) {
-        (Some(self.scan_start), Some(self.scan_end), Some(self.chain_tip))
+        (
+            Some(self.scan_start),
+            Some(self.scan_end),
+            Some(self.chain_tip),
+        )
     }
 }
 
@@ -257,14 +261,7 @@ pub async fn sync_wallet_notes(
 
     let zebra_client = ZebraClient::from_config(&config);
     let chain_tip = zebra_client.get_block_count().await.map_err(|e| {
-        WalletSyncError::with_range(
-            WalletSyncPhase::Connect,
-            e,
-            None,
-            None,
-            None,
-            None,
-        )
+        WalletSyncError::with_range(WalletSyncPhase::Connect, e, None, None, None, None)
     })?;
     let range = resolve_scan_range(&config, &options, chain_tip).map_err(|e| {
         WalletSyncError::with_range(


### PR DESCRIPTION
## Summary

Improves `/api/sync` observability for integrators and testers (including Gilmore's report: verbose decrypt logs followed by an opaque HTTP 500 after ~39s).

- **Structured sync errors** — failures return JSON with `phase`, `block_height`, scan range, and `code` instead of a generic tower_http 500.
- **Quieter scan logs** — per-action Orchard decrypt chatter is off by default in api-server / non-TTY builds.
- **Zebra outages** — sync failures caused by Zebra unavailability return **503** + `ZEBRA_UNAVAILABLE` (same pattern as `/api/transaction/send`).

---

## Problem

During `POST /api/sync`, the api-server previously:

1. Logged misleading per-action lines (`NOTE DECRYPTION STATUS: FULLY IMPLEMENTED`) on **every** Orchard action attempt — not only on success — flooding stdout.
2. Returned only `{"error":"Sync failed: …"}` on failure, with no indication of **where** sync failed (RPC fetch vs witness vs `notes.json` persist).

Integrators hitting a 500 had to grep server logs; the response body was not actionable.

---

## What changed

### Structured `/api/sync` errors

`sync_wallet_notes` now returns `WalletSyncError` with phase context. The api-server maps this to JSON:

| Field | Description |
|-------|-------------|
| `error` | Human-readable message |
| `code` | Machine-readable code (see below) |
| `phase` | Pipeline stage where failure occurred |
| `block_height` | Block number when failure happened mid-scan (if applicable) |
| `scan_start` / `scan_end` | Inclusive scan range for this sync call |
| `chain_tip` | Zebra tip at sync start |

**Phases** (`phase`):

| Phase | Meaning |
|-------|---------|
| `connect` | Could not reach Zebra / read chain tip |
| `resolve_range` | Failed to compute scan bounds from config |
| `load_notes` | Failed to read cached `notes.json` |
| `scan` | Orchard scan failed (RPC, parse, decrypt, witness) |
| `persist` | Failed to write merged `notes.json` |
| `checkpoint` | Failed to update `last_scan_height` in config |

**Codes** (`code`):

| Code | HTTP | When |
|------|------|------|
| `ZEBRA_UNAVAILABLE` | 503 | Zebra node unreachable / connection refused |
| `SYNC_CONNECT_FAILED` | 500 | Other connect/tip errors |
| `SYNC_RANGE_FAILED` | 500 | Range resolution |
| `SYNC_LOAD_NOTES_FAILED` | 500 | Read `notes.json` |
| `SYNC_SCAN_FAILED` | 500 | Mid-range scan failure |
| `SYNC_PERSIST_FAILED` | 500 | Write `notes.json` |
| `SYNC_CHECKPOINT_FAILED` | 500 | Update `last_scan_height` |

**Example — scan failure at a specific block:**

```json
{
  "error": "Orchard scan failed at block 3050123: …",
  "code": "SYNC_SCAN_FAILED",
  "phase": "scan",
  "block_height": 3050123,
  "scan_start": 3050001,
  "scan_end": 3051000,
  "chain_tip": 3060000
}
```

**Example — Zebra down:**

```json
{
  "error": "Network connection failed: …",
  "code": "ZEBRA_UNAVAILABLE",
  "phase": "scan",
  "block_height": null,
  "scan_start": 3050001,
  "scan_end": 3051000,
  "chain_tip": 3060000
}
```

Success responses are unchanged (`success`, `balance_zatoshis`, `already_synced`, etc.).

### Quieter Orchard scan logging

New `src/scan_log.rs`:

| Mode | Behavior |
|------|----------|
| **Default** (api-server, non-TTY) | No indicatif progress bar; no per-action decrypt `println!`; high-level events via `tracing::info` |
| `NOZY_VERBOSE_SCAN=1` | Restores per-action decrypt `println!` spam (debugging) |
| `RUST_LOG=nozy::notes=debug` | Decrypt detail via `tracing::debug` without stdout flood |
| Interactive CLI (TTY) | Progress bar + scan summary as before |

The `FULLY IMPLEMENTED` lines were development-era noise printed on every action trial-decrypt, not a success indicator.

---

## Files touched

- `src/scan_log.rs` — logging gates
- `src/notes.rs` — quiet decrypt; `NozyError::ScanAtBlock`
- `src/wallet_sync.rs` — `WalletSyncError` / `WalletSyncPhase`
- `src/error.rs` — `ScanAtBlock` variant + `scan_block_height()`
- `api-server/src/handlers.rs` — structured error JSON on sync failure
- `CHANGELOG.md`

---

## How to test (Gilmore / integrators)

### Rebuild api-server

```bash
git fetch origin feat/sync-structured-errors
git checkout feat/sync-structured-errors
cargo build --release -p nozywallet-api
```

Restart `nozywallet-api` with your usual config (`zebra_url`, wallet path, etc.).

### Happy path

```bash
curl -s -X POST http://127.0.0.1:3000/api/sync \
  -H "Content-Type: application/json" \
  -d '{"password":"YOUR_PASSWORD"}' | jq
```

Expect same success fields as before. Second sync at tip should return `already_synced: true`.

### Failure path (what we need from you)

If sync still fails, **paste the full JSON response body** — not just the HTTP status. It should now include `phase` and `block_height` when the failure is mid-scan.

Optional: enable verbose scan logs for one repro:

```bash
NOZY_VERBOSE_SCAN=1 ./target/release/nozywallet-api
```

### Confirm log noise is gone

Without `NOZY_VERBOSE_SCAN`, server stdout should **not** print per-action decrypt lines during sync. You should see at most sparse `tracing::info` lines (if `RUST_LOG` includes `info`).

---

## Test plan (maintainer)

- [ ] Rebuild `nozywallet-api` from this branch
- [ ] `POST /api/sync` at tip — success path unchanged
- [ ] Stop Zebra mid-sync — **503** + `ZEBRA_UNAVAILABLE`
- [ ] Scan failure — response includes `phase: "scan"` and `block_height` when applicable
- [ ] Persist failure — `phase: "persist"` (if reproducible)
- [ ] No per-action decrypt spam unless `NOZY_VERBOSE_SCAN=1`
- [ ] `cargo fmt`, CI green

---

## Related

- Follow-up to Gilmore's `/api/sync` 500 after verbose decrypt logs (~39s)
- Builds on #75 (sync persistence / `already_synced`) and #76 (speed-up surfaces)
