### PR TITLE
fix(zebra): retry transient getblock response read/decode failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### Fixed
 
+- **Zebra RPC during scan:** retry transient `getblock` transport failures (`error decoding response body`, truncated reads) instead of failing the whole `/api/sync` on first glitch.
 - **`/api/sync` repeat calls:** when already caught up to chain tip, return cached balance without rescanning; serialize concurrent syncs; richer sync response (`balance_zatoshis`, `already_synced`, `total_notes`).
 - **api-server send:** mark notes spent in `notes.json` after broadcast (match CLI).
 - **Transaction history note marking:** use v2 `notes.json` index format when marking spent notes.

--- a/src/zebra_integration.rs
+++ b/src/zebra_integration.rs
@@ -14,6 +14,23 @@ use std::net::IpAddr;
 use std::path::PathBuf;
 use std::sync::Arc;
 
+/// Transient Zebra JSON-RPC transport errors worth retrying with exponential backoff.
+fn is_retryable_zebra_transport_error(msg: &str) -> bool {
+    let m = msg.to_lowercase();
+    m.contains("failed to connect")
+        || m.contains("connection refused")
+        || m.contains("connection failed")
+        || m.contains("connection reset")
+        || m.contains("connection closed")
+        || m.contains("broken pipe")
+        || m.contains("timeout")
+        || m.contains("error sending request")
+        // reqwest body read/decode failures under load (Gilmore: "error decoding response body")
+        || m.contains("failed to read response")
+        || m.contains("decoding response body")
+        || m.contains("unexpected eof")
+}
+
 #[derive(Debug, Clone)]
 pub struct ZebraClient {
     url: String,
@@ -815,17 +832,7 @@ This blocks remote RPC only; localhost RPC remains allowed.",
                                 }
                             };
 
-                            let m = error_msg.to_lowercase();
-                            // Match reqwest / OS phrasing; `try_request` uses "Connection failed to …"
-                            // and generic "error sending request for url", which previously skipped retries.
-                            if m.contains("failed to connect")
-                                || m.contains("connection refused")
-                                || m.contains("connection failed")
-                                || m.contains("connection reset")
-                                || m.contains("broken pipe")
-                                || m.contains("timeout")
-                                || m.contains("error sending request")
-                            {
+                            if is_retryable_zebra_transport_error(error_msg) {
                                 let delay_ms = 100 * (1 << attempt);
                                 tokio::time::sleep(tokio::time::Duration::from_millis(delay_ms))
                                     .await;
@@ -1020,4 +1027,30 @@ pub struct OrchardTreeState {
     pub height: u32,
     pub anchor: [u8; 32],
     pub commitment_count: u64,
+}
+
+#[cfg(test)]
+mod transport_retry_tests {
+    use super::is_retryable_zebra_transport_error;
+
+    #[test]
+    fn retries_response_body_decode_errors() {
+        assert!(is_retryable_zebra_transport_error(
+            "Failed to read response: error decoding response body"
+        ));
+    }
+
+    #[test]
+    fn retries_connection_failures() {
+        assert!(is_retryable_zebra_transport_error(
+            "Connection failed to http://127.0.0.1:8232: connection refused"
+        ));
+    }
+
+    #[test]
+    fn does_not_retry_invalid_rpc_payload() {
+        assert!(!is_retryable_zebra_transport_error(
+            "Zebra RPC error: block not found (code: -5)"
+        ));
+    }
 }


### PR DESCRIPTION
## Summary

Follow-up to Gilmore's `/api/sync` tester feedback ([#77](https://github.com/LEONINE-DAO/Nozy-wallet/pull/77)).

Gilmore hit a sync failure at **block 3379058** with `error decoding response body`, then **retried and the same block succeeded**. That pattern points to a **transient Zebra RPC transport glitch**, not bad block content, decrypt bugs, or wallet state corruption.

This PR expands `ZebraClient::make_request` so **reqwest body read/decode failures** are retried (up to 3 attempts with exponential backoff), same as connection resets and timeouts. One flaky `getblock` response should no longer abort an entire `/api/sync`.

---

## Problem

### Gilmore's report

API response when sync failed:

```json
{
  "error": "Sync failed: Network error: Failed to fetch block 3379058 while scanning notes: Network error: Failed to get block: Network error: Failed to read response: error decoding response body"
}
```

On manual retry, block **3379058 passed** and scanning continued. Failure was **not deterministic** to that block.

### What actually failed

During Orchard scan, Nozy fetches blocks via Zebra JSON-RPC:

1. `getblockhash` (height)
2. `getblock` (hash, **verbosity 2**) — large JSON payloads

The scan path fetches blocks in **parallel batches** (default 5 at a time). Under load, Zebrad can occasionally return a response that reqwest cannot fully read/decode (`error decoding response body` / truncated body).

That is a **transport-layer** failure between Nozy and Zebrad — not Orchard decrypt, not `notes.json` persistence, not invalid block data at that height.

### Why retry "fixed" it but sync didn't

`ZebraClient::make_request` already retried:

- connection refused / reset
- timeouts
- broken pipe
- `error sending request`

It did **not** retry:

- `Failed to read response: error decoding response body`
- other truncated-body / unexpected EOF read failures

So Gilmore's manual retry worked, but **in-process sync aborted on the first glitch** with no automatic retry for this error class.

---

## What changed

### New helper: `is_retryable_zebra_transport_error`

Centralizes classification of transient transport errors in `src/zebra_integration.rs`.

**Newly retryable** (in addition to existing connection/timeout cases):

| Error substring | Typical cause |
|-----------------|---------------|
| `failed to read response` | reqwest could not read full HTTP body |
| `decoding response body` | Body decode/decompression failure |
| `unexpected eof` | Truncated response mid-stream |
| `connection closed` | Server closed connection early |

**Still not retried** (fail fast):

- Valid HTTP response with Zebra RPC error payload (e.g. `block not found`)
- Malformed JSON that is clearly a permanent RPC error

### Retry behavior (unchanged mechanics)

- Up to **3 retries** per URL (4 total attempts)
- Exponential backoff: 100ms → 200ms → 400ms
- Fallback URLs still tried in order when configured

### Relationship to #77

| PR | What it does |
|----|----------------|
| **#77** (merged) | Structured `/api/sync` errors (`phase`, `block_height`, `code`); quieter scan logs |
| **#78** (this) | Automatic retry so many transient fetch failures never surface as errors |

After both are deployed, Gilmore should see:

1. **Fewer** sync failures from one-off decode glitches (automatic retry)
2. When failures still occur, **actionable JSON** from #77 instead of opaque `Sync failed: …`

Example structured failure (if all retries exhaust):

```json
{
  "error": "Orchard scan failed at block 3379058: Failed to fetch block while scanning notes: …",
  "code": "SYNC_SCAN_FAILED",
  "phase": "scan",
  "block_height": 3379058,
  "scan_start": 3378001,
  "scan_end": 3379000,
  "chain_tip": 3400000
}
```

---

## Files touched

- `src/zebra_integration.rs` — `is_retryable_zebra_transport_error`, unit tests
- `CHANGELOG.md`

---

## How to test (Gilmore / integrators)

### Rebuild

```bash
git fetch origin
git checkout feat/zebra-rpc-transient-retry   # or master after merge
cargo build --release -p nozywallet-api
```

Restart `nozywallet-api`.

### Long sync

Run `POST /api/sync` over a large height range (or incremental sync from a wallet behind tip). Occasional Zebra hiccups should be absorbed by automatic retries instead of failing the whole sync.

### If sync still fails

Paste the **full JSON response body** (post-#77 format). Include:

- `phase`
- `block_height`
- `scan_start` / `scan_end`
- whether retrying the **same** sync call immediately succeeds (transient vs persistent)

Optional verbose logging:

```bash
RUST_LOG=nozy=info,nozy::notes=debug ./target/release/nozywallet-api
```

---

## Test plan (maintainer)

- [x] Unit tests: `decoding response body` classified as retryable
- [x] Unit tests: connection refused retryable; RPC semantic errors not
- [ ] `cargo fmt` / CI green
- [ ] Gilmore: long sync on mainnet-ish range; confirm fewer aborts on transient glitches
- [ ] If still flaky after merge: consider lowering `parallel_blocks` for api-server or increasing local Zebra HTTP timeout for verbosity-2 `getblock`

---

## Future work (out of scope for this PR)

If intermittent failures continue after automatic retries:

1. **Lower parallel block fetch** in api-server (e.g. 5 → 2) to reduce Zebrad load
2. **Longer timeout** for local `getblock` verbosity 2 (multi-MB JSON)
3. **Per-block retry** at scan layer with block-level logging (in addition to RPC-layer retry)
4. **Compact-block scan path** (lightwalletd / Zeaking) to avoid huge verbosity-2 RPC payloads long-term

---

## Related

- Gilmore tester feedback on `/api/sync` 500 at block 3379058
- [#77](https://github.com/LEONINE-DAO/Nozy-wallet/pull/77) — structured sync errors + quieter scan logs
- [#75](https://github.com/LEONINE-DAO/Nozy-wallet/pull/75) — sync persistence / `already_synced`
