### PR TITLE
Fix Zebra tx confirmation detection (wallet history)

### DIFF
--- a/src/transaction_history.rs
+++ b/src/transaction_history.rs
@@ -524,6 +524,30 @@ impl SentTransactionStorage {
             .unwrap_or_default()
     }
 
+    /// Pending and wrongly-expired broadcasts that may still need chain reconciliation.
+    fn get_transactions_needing_confirmation(&self) -> Vec<SentTransactionRecord> {
+        self.transactions
+            .lock()
+            .map_err(|e| {
+                eprintln!(
+                    "Warning: Mutex poisoned in get_transactions_needing_confirmation: {}",
+                    e
+                );
+            })
+            .ok()
+            .map(|transactions| {
+                transactions
+                    .values()
+                    .filter(|tx| {
+                        tx.status == TransactionStatus::Pending
+                            || (tx.status == TransactionStatus::Expired && tx.broadcast_at.is_some())
+                    })
+                    .cloned()
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
     pub fn update_transaction_status(
         &self,
         txid: &str,
@@ -595,7 +619,7 @@ impl SentTransactionStorage {
         &self,
         zebra_client: &crate::zebra_integration::ZebraClient,
     ) -> NozyResult<usize> {
-        let pending = self.get_pending_transactions();
+        let pending = self.get_transactions_needing_confirmation();
         let mut updated_count = 0;
 
         for tx in pending {
@@ -641,12 +665,26 @@ impl SentTransactionStorage {
 
         let mut expired_count = 0usize;
         for (txid, spent_note_ids) in expired_candidates {
-            if zebra_client
-                .check_transaction_exists(&txid)
-                .await
-                .unwrap_or(false)
-            {
-                continue;
+            match zebra_client.get_transaction_info(&txid).await {
+                Ok(info) => {
+                    if info.block_height.is_some() {
+                        let _ = self
+                            .check_transaction_confirmation(zebra_client, &txid)
+                            .await?;
+                        continue;
+                    }
+                    // Node still reports the tx (e.g. mempool); do not expire.
+                    continue;
+                }
+                Err(crate::error::NozyError::InvalidOperation(msg))
+                    if msg.contains("No transaction") =>
+                {
+                    // Fall through to mark expired.
+                }
+                Err(_) => {
+                    // RPC error: skip rather than falsely expiring a mined tx.
+                    continue;
+                }
             }
 
             let marked = self.mark_transaction_expired(&txid)?;

--- a/src/transaction_history.rs
+++ b/src/transaction_history.rs
@@ -540,7 +540,8 @@ impl SentTransactionStorage {
                     .values()
                     .filter(|tx| {
                         tx.status == TransactionStatus::Pending
-                            || (tx.status == TransactionStatus::Expired && tx.broadcast_at.is_some())
+                            || (tx.status == TransactionStatus::Expired
+                                && tx.broadcast_at.is_some())
                     })
                     .cloned()
                     .collect()

--- a/src/zebra_client.rs
+++ b/src/zebra_client.rs
@@ -95,7 +95,7 @@ impl ZebraClient {
     }
 
     pub async fn get_transaction(&self, txid: &str) -> NozyResult<TransactionInfo> {
-        let response = self.make_rpc_call("getrawtransaction", json!([txid, true])).await?;
+        let response = self.make_rpc_call("getrawtransaction", json!([txid, 1])).await?;
         
         let mut orchard_actions = Vec::new();
         
@@ -118,9 +118,15 @@ impl ZebraClient {
             }
         }
 
+        let block_height = response
+            .get("height")
+            .or_else(|| response.get("blockheight"))
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0) as u32;
+
         Ok(TransactionInfo {
             txid: txid.to_string(),
-            block_height: response["blockheight"].as_u64().unwrap_or(0) as u32,
+            block_height,
             orchard_actions,
         })
     }

--- a/src/zebra_integration.rs
+++ b/src/zebra_integration.rs
@@ -981,14 +981,15 @@ This blocks remote RPC only; localhost RPC remains allowed.",
         let block_height = parse_tx_block_height(&tx_data);
         let block_hash = parse_tx_block_hash(&tx_data);
 
-        let confirmations = if let Some(conf) = tx_data.get("confirmations").and_then(|v| v.as_u64()) {
-            conf as u32
-        } else if let Some(height) = block_height {
-            let current_height = self.get_block_count().await.unwrap_or(0);
-            current_height.saturating_sub(height) + 1
-        } else {
-            0
-        };
+        let confirmations =
+            if let Some(conf) = tx_data.get("confirmations").and_then(|v| v.as_u64()) {
+                conf as u32
+            } else if let Some(height) = block_height {
+                let current_height = self.get_block_count().await.unwrap_or(0);
+                current_height.saturating_sub(height) + 1
+            } else {
+                0
+            };
 
         Ok(TransactionInfo {
             txid: txid.to_string(),

--- a/src/zebra_integration.rs
+++ b/src/zebra_integration.rs
@@ -961,7 +961,7 @@ This blocks remote RPC only; localhost RPC remains allowed.",
         let request = serde_json::json!({
             "jsonrpc": "2.0",
             "method": "getrawtransaction",
-            "params": [txid, true],
+            "params": [txid, 1],
             "id": 1
         });
 
@@ -978,17 +978,12 @@ This blocks remote RPC only; localhost RPC remains allowed.",
             NozyError::InvalidOperation("No transaction data in response".to_string())
         })?;
 
-        let block_height = tx_data
-            .get("blockheight")
-            .and_then(|v| v.as_u64())
-            .map(|h| h as u32);
+        let block_height = parse_tx_block_height(&tx_data);
+        let block_hash = parse_tx_block_hash(&tx_data);
 
-        let block_hash = tx_data
-            .get("blockhash")
-            .and_then(|v| v.as_str())
-            .map(|s| s.to_string());
-
-        let confirmations = if let Some(height) = block_height {
+        let confirmations = if let Some(conf) = tx_data.get("confirmations").and_then(|v| v.as_u64()) {
+            conf as u32
+        } else if let Some(height) = block_height {
             let current_height = self.get_block_count().await.unwrap_or(0);
             current_height.saturating_sub(height) + 1
         } else {
@@ -1013,6 +1008,23 @@ This blocks remote RPC only; localhost RPC remains allowed.",
     }
 }
 
+/// Zebra `getrawtransaction` uses `height`; some stacks use `blockheight`.
+fn parse_tx_block_height(tx_data: &serde_json::Value) -> Option<u32> {
+    tx_data
+        .get("height")
+        .or_else(|| tx_data.get("blockheight"))
+        .and_then(|v| v.as_u64())
+        .map(|h| h as u32)
+}
+
+fn parse_tx_block_hash(tx_data: &serde_json::Value) -> Option<String> {
+    tx_data
+        .get("blockhash")
+        .or_else(|| tx_data.get("block_hash"))
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+}
+
 #[derive(Debug, Clone)]
 pub struct TransactionInfo {
     pub txid: String,
@@ -1027,6 +1039,29 @@ pub struct OrchardTreeState {
     pub height: u32,
     pub anchor: [u8; 32],
     pub commitment_count: u64,
+}
+
+#[cfg(test)]
+mod tx_field_parsing_tests {
+    use super::{parse_tx_block_hash, parse_tx_block_height};
+
+    #[test]
+    fn parses_zebra_height_field() {
+        let tx = serde_json::json!({
+            "height": 3381141,
+            "blockhash": "abc123",
+            "confirmations": 11
+        });
+        assert_eq!(parse_tx_block_height(&tx), Some(3381141));
+        assert_eq!(parse_tx_block_hash(&tx).as_deref(), Some("abc123"));
+    }
+
+    #[test]
+    fn falls_back_to_blockheight_field() {
+        let tx = serde_json::json!({ "blockheight": 100, "block_hash": "deadbeef" });
+        assert_eq!(parse_tx_block_height(&tx), Some(100));
+        assert_eq!(parse_tx_block_hash(&tx).as_deref(), Some("deadbeef"));
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- Fix `getrawtransaction` calls to use Zebra-compatible numeric verbosity (`1`) instead of boolean `true` (was returning `Invalid params` and never detecting confirmations).
- Parse block height from Zebra's `height` field (with `blockheight` fallback) and use RPC `confirmations` when present.
- Reconcile wrongly-expired broadcasts during `check-confirmations` and avoid marking txs expired on RPC errors.

Closes #79

## Test plan

- [x] `cargo test --lib` passes (including new `tx_field_parsing_tests`)
- [x] Mainnet wallet: `nozy check-confirmations` updates speed-up tx to **Confirmed** (block 3381141)
- [x] Mainnet wallet: original pilot send also reconciled to **Confirmed** (block 3373644)
