### PR TITLE
Unified Zebra RPC policy + trusted operator URLs

### DIFF
--- a/api-server/src/handlers.rs
+++ b/api-server/src/handlers.rs
@@ -569,7 +569,7 @@ pub async fn send_transaction(
             }
         })?;
 
-    let zebra_client = ZebraClient::new(zebra_url.clone());
+    let zebra_client = ZebraClient::from_config_with_url(&config, Some(&zebra_url));
 
     let tip_height = zebra_client.get_best_block_height().await.map_err(|e| {
         let msg = e.to_string();
@@ -764,25 +764,46 @@ pub async fn set_theme(
 
 pub async fn test_zebra_connection(
     Json(payload): Json<TestZebraRequest>,
-) -> Result<ResponseJson<String>, (StatusCode, ResponseJson<serde_json::Value>)> {
-    use nozy::{load_config, ZebraClient};
+) -> Result<ResponseJson<serde_json::Value>, (StatusCode, ResponseJson<serde_json::Value>)> {
+    use nozy::{load_config, zebra_connect_api_code, ZebraClient};
 
     let config = load_config();
     let url = payload
         .zebra_url
+        .clone()
         .unwrap_or_else(|| config.zebra_url.clone());
 
-    let client = ZebraClient::new(url.clone());
+    let client = ZebraClient::from_config_with_url(&config, payload.zebra_url.as_deref());
+    let connection_mode = client.connection_mode().as_str().to_string();
+
     match client.get_block_count().await {
-        Ok(block_count) => Ok(ResponseJson(format!(
-            "✅ Connected to Zebra node at {url}\nBlock height: {block_count}"
-        ))),
-        Err(e) => Err((
-            StatusCode::BAD_REQUEST,
-            ResponseJson(serde_json::json!({
-                "error": format!("❌ Failed to connect: {}", e)
-            })),
-        )),
+        Ok(block_count) => Ok(ResponseJson(serde_json::json!({
+            "ok": true,
+            "zebra_url": url,
+            "connection_mode": connection_mode,
+            "block_height": block_count,
+            "message": format!("Connected to Zebra at {url}. Block height: {block_count}"),
+        }))),
+        Err(e) => {
+            let msg = e.to_string();
+            let code = zebra_connect_api_code(&msg);
+            let status = if code == "PRIVACY_POLICY_BLOCKED" || code == "TOR_PROXY_UNREACHABLE" {
+                StatusCode::SERVICE_UNAVAILABLE
+            } else {
+                StatusCode::BAD_GATEWAY
+            };
+            Err((
+                status,
+                ResponseJson(serde_json::json!({
+                    "ok": false,
+                    "zebra_url": url,
+                    "connection_mode": connection_mode,
+                    "error": msg,
+                    "code": code,
+                    "message": format!("Failed to connect to Zebra at {url}: {msg}"),
+                })),
+            ))
+        }
     }
 }
 
@@ -1066,7 +1087,7 @@ pub async fn check_transaction_confirmations(
     use nozy::{load_config, transaction_history::SentTransactionStorage, ZebraClient};
 
     let config = load_config();
-    let zebra_client = ZebraClient::new(config.zebra_url);
+    let zebra_client = ZebraClient::from_config(&config);
     let tx_storage = SentTransactionStorage::new().map_err(|e| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -1321,7 +1342,7 @@ pub async fn get_wallet_status(
     };
 
     let config = load_config();
-    let zebra_client = ZebraClient::new(config.zebra_url.clone());
+    let zebra_client = ZebraClient::from_config(&config);
 
     let balance_zatoshis = load_wallet_notes()
         .map(|notes| wallet_unspent_balance_zatoshis(&notes))

--- a/desktop-client/src-tauri/src/commands/config.rs
+++ b/desktop-client/src-tauri/src/commands/config.rs
@@ -49,16 +49,19 @@ pub async fn test_zebra_connection(
         .zebra_url
         .unwrap_or_else(|| config.zebra_url.clone());
 
-    let zebra_client = ZebraClient::new(zebra_url.clone());
+    let zebra_client = ZebraClient::from_config_with_url(
+        &config,
+        request.zebra_url.as_deref(),
+    );
+    let connection_mode = zebra_client.connection_mode().as_str();
 
     match zebra_client.get_block_count().await {
         Ok(block_count) => Ok(format!(
-            "✅ Connected to Zebra at {}. Current block height: {}",
-            zebra_url, block_count
+            "Connected to Zebra at {zebra_url} ({connection_mode}). Current block height: {block_count}"
         )),
         Err(e) => Err(TauriError {
-            message: format!("Failed to connect to Zebra at {}: {}", zebra_url, e),
-            code: Some("CONNECTION_FAILED".to_string()),
+            message: format!("Failed to connect to Zebra at {zebra_url}: {e}"),
+            code: Some(nozy::zebra_connect_api_code(&e.to_string()).to_string()),
         }),
     }
 }

--- a/src/cli_helpers.rs
+++ b/src/cli_helpers.rs
@@ -31,6 +31,25 @@ pub fn is_zebra_unavailable_error(err: &str) -> bool {
     err.contains("Failed to connect to Zebra")
         || err.contains("Connection failed to")
         || err.contains("Is Zebra running")
+        || err.contains("Remote Zebra RPC blocked")
+        || err.contains("privacy proxy configuration is invalid")
+}
+
+/// Structured connect-phase code for API clients (sync, test-zebra, send).
+pub fn zebra_connect_api_code(err: &str) -> &'static str {
+    let m = err.to_ascii_lowercase();
+    if m.contains("remote zebra rpc blocked") || m.contains("privacy policy active") {
+        "PRIVACY_POLICY_BLOCKED"
+    } else if m.contains("privacy proxy") || m.contains("invalid privacy proxy") {
+        "TOR_PROXY_UNREACHABLE"
+    } else if m.contains("failed to connect to zebra")
+        || m.contains("connection failed to")
+        || m.contains("is zebra running")
+    {
+        "ZEBRA_RPC_UNREACHABLE"
+    } else {
+        "ZEBRA_RPC_ERROR"
+    }
 }
 
 /// ZIP-317 client-side fee for an Orchard send (Zebrad does not implement `estimatefee`).

--- a/src/config.rs
+++ b/src/config.rs
@@ -28,6 +28,12 @@ pub struct WalletConfig {
     #[serde(default)]
     pub zebra_fallback_urls: Vec<String>,
 
+    /// Operator-controlled Zebra RPC endpoints allowed to connect directly (no Tor) when
+    /// `privacy_network.require_privacy_network` is true. Public/community nodes should not
+    /// be listed here; use Tor/onion for those.
+    #[serde(default)]
+    pub trusted_zebra_urls: Vec<String>,
+
     #[serde(default = "default_crosslink_url")]
     pub crosslink_url: String,
 
@@ -179,6 +185,7 @@ impl Default for WalletConfig {
         Self {
             zebra_url: default_zebra_url(),
             zebra_fallback_urls: Vec::new(),
+            trusted_zebra_urls: Vec::new(),
             crosslink_url: default_crosslink_url(),
             network: default_network(),
             last_scan_height: None,
@@ -238,6 +245,78 @@ pub fn load_config() -> WalletConfig {
     }
 
     config
+}
+
+/// Normalize Zebra RPC URLs for comparison (config trust list, overrides).
+pub fn normalize_zebra_rpc_url(url: &str) -> String {
+    let mut url = url.trim().to_string();
+    url = url.replace("..", ".");
+    url = url.replace(":///", "://");
+    if url.starts_with("http://") {
+        url = url.replace("http:///", "http://");
+    } else if url.starts_with("https://") {
+        url = url.replace("https:///", "https://");
+    }
+
+    if url.starts_with("http://") || url.starts_with("https://") {
+        return url;
+    }
+
+    if let Some((host, port_str)) = url.split_once(':') {
+        if let Ok(port) = port_str.parse::<u16>() {
+            if port == 443 {
+                return format!("https://{host}");
+            }
+            return format!("http://{url}");
+        }
+        let _ = host;
+    }
+
+    if url.starts_with("127.0.0.1")
+        || url.starts_with("localhost")
+        || url.starts_with("172.")
+        || url.starts_with("10.")
+        || url.starts_with("192.168.")
+    {
+        format!("http://{url}")
+    } else {
+        format!("https://{url}")
+    }
+}
+
+impl WalletConfig {
+    /// Config with an optional runtime Zebra URL override (API/CLI).
+    pub fn with_zebra_url_override(mut self, zebra_url: Option<String>) -> Self {
+        if let Some(url) = zebra_url {
+            let trimmed = url.trim();
+            if !trimmed.is_empty() {
+                self.zebra_url = trimmed.to_string();
+            }
+        }
+        self
+    }
+
+    pub fn is_trusted_zebra_url(&self, url: &str) -> bool {
+        let normalized = normalize_zebra_rpc_url(url);
+        self.trusted_zebra_urls
+            .iter()
+            .any(|trusted| normalize_zebra_rpc_url(trusted) == normalized)
+    }
+}
+
+#[cfg(test)]
+mod config_tests {
+    use super::*;
+
+    #[test]
+    fn trusted_url_matches_normalized_forms() {
+        let mut config = WalletConfig::default();
+        config
+            .trusted_zebra_urls
+            .push("http://node.example.com:8232".to_string());
+        assert!(config.is_trusted_zebra_url("http://node.example.com:8232"));
+        assert!(config.is_trusted_zebra_url("node.example.com:8232"));
+    }
 }
 
 pub fn save_config(config: &WalletConfig) -> NozyResult<()> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,7 +125,7 @@ pub use bridge::{
 pub use cli_helpers::{
     cached_unspent_balance_zatoshis, estimate_transaction_fee, estimate_transaction_fee_for_send,
     format_insufficient_funds_message, is_insufficient_funds_error, is_zebra_unavailable_error,
-    scan_notes_for_sending,
+    scan_notes_for_sending, zebra_connect_api_code,
 };
 #[cfg(feature = "native")]
 pub use config::{load_config, save_config, update_last_scan_height, WalletConfig};
@@ -193,4 +193,4 @@ pub use zeaking::{IndexStats, IndexedBlock, IndexedTransaction, Zeaking};
 #[cfg(feature = "native")]
 pub use zeaking_adapter::{ZebraBlockParser, ZebraBlockSource};
 #[cfg(feature = "native")]
-pub use zebra_integration::ZebraClient;
+pub use zebra_integration::{ZebraClient, ZebraConnectionMode};

--- a/src/tx_lifecycle.rs
+++ b/src/tx_lifecycle.rs
@@ -1,6 +1,7 @@
 //! Dynamic-fee pilot lifecycle: expiry detection, balance release, and speed-up rebuild.
 
 use crate::cli_helpers::scan_notes_for_sending;
+use crate::config::load_config;
 use crate::error::{NozyError, NozyResult};
 use crate::fee_policy::{
     estimate_orchard_send_fee_zatoshis, PilotSendOptions, PILOT_EXPIRY_DELTA_BLOCKS,
@@ -29,7 +30,11 @@ pub async fn speed_up_transaction(
     original_txid: &str,
 ) -> NozyResult<String> {
     let tx_storage = SentTransactionStorage::new()?;
-    let zebra_client = ZebraClient::new(zebra_url.to_string());
+    let mut config = load_config();
+    if config.zebra_url != zebra_url {
+        config.zebra_url = zebra_url.to_string();
+    }
+    let zebra_client = ZebraClient::from_config(&config);
 
     tx_storage
         .check_expired_pending_transactions(&zebra_client)

--- a/src/wallet_sync.rs
+++ b/src/wallet_sync.rs
@@ -77,7 +77,9 @@ impl WalletSyncError {
     }
 
     pub fn api_code(&self) -> &str {
-        if self.is_zebra_unavailable() {
+        if self.phase == WalletSyncPhase::Connect {
+            crate::cli_helpers::zebra_connect_api_code(&self.message)
+        } else if self.is_zebra_unavailable() {
             "ZEBRA_UNAVAILABLE"
         } else {
             self.phase.error_code()

--- a/src/zebra_integration.rs
+++ b/src/zebra_integration.rs
@@ -1,4 +1,4 @@
-use crate::config::{BackendKind, Protocol, WalletConfig};
+use crate::config::{normalize_zebra_rpc_url, BackendKind, Protocol, WalletConfig};
 use crate::error::{NozyError, NozyResult};
 use crate::grpc_client::ZebraGrpcClient;
 use crate::zebra_tree_rpc::{
@@ -7,6 +7,7 @@ use crate::zebra_tree_rpc::{
 };
 use hex;
 use serde::Deserialize;
+use serde::Serialize;
 use serde_json::Value;
 use std::collections::HashMap;
 use std::fs;
@@ -31,6 +32,30 @@ fn is_retryable_zebra_transport_error(msg: &str) -> bool {
         || m.contains("unexpected eof")
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ZebraConnectionMode {
+    DirectLocal,
+    DirectTrusted,
+    DirectRemote,
+    TorProxy,
+    I2pProxy,
+    Blocked,
+}
+
+impl ZebraConnectionMode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::DirectLocal => "direct_local",
+            Self::DirectTrusted => "direct_trusted",
+            Self::DirectRemote => "direct_remote",
+            Self::TorProxy => "tor_proxy",
+            Self::I2pProxy => "i2p_proxy",
+            Self::Blocked => "blocked",
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct ZebraClient {
     url: String,
@@ -48,6 +73,7 @@ pub struct ZebraClient {
     privacy_proxy_url: Option<String>,
     block_remote_without_privacy: bool,
     privacy_block_reason: Option<String>,
+    connection_mode: ZebraConnectionMode,
     #[allow(dead_code)]
     grpc_client: Option<Arc<ZebraGrpcClient>>,
 }
@@ -260,11 +286,32 @@ impl ZebraClient {
             privacy_proxy_url: None,
             block_remote_without_privacy: false,
             privacy_block_reason: None,
+            connection_mode: if is_local {
+                ZebraConnectionMode::DirectLocal
+            } else {
+                ZebraConnectionMode::DirectRemote
+            },
             grpc_client: None,
         }
     }
 
-    pub fn from_config(config: &crate::config::WalletConfig) -> Self {
+    pub fn connection_mode(&self) -> ZebraConnectionMode {
+        self.connection_mode
+    }
+
+    pub fn from_config(config: &WalletConfig) -> Self {
+        Self::from_config_with_url(config, None)
+    }
+
+    /// Unified wallet Zebra client: applies privacy policy, trusted operator URLs, and Tor/I2P.
+    pub fn from_config_with_url(config: &WalletConfig, zebra_url_override: Option<&str>) -> Self {
+        let effective = config
+            .clone()
+            .with_zebra_url_override(zebra_url_override.map(|s| s.to_string()));
+        Self::build_from_config(&effective)
+    }
+
+    fn build_from_config(config: &WalletConfig) -> Self {
         let (backend, url, fallback_urls) = match &config.backend {
             BackendKind::Zebra => (
                 BackendKind::Zebra,
@@ -284,17 +331,27 @@ impl ZebraClient {
         let mut client = Self::new_with_backend_and_protocol(url, backend, config.protocol.clone());
         client.fallback_urls = fallback_urls
             .into_iter()
-            .map(Self::normalize_url)
+            .map(|u| Self::normalize_url(u))
             .filter(|u| !u.is_empty())
             .collect();
 
-        let primary_is_remote = !Self::is_local_url(&client.url);
+        let primary_local = Self::is_local_url(&client.url);
+        let primary_trusted = config.is_trusted_zebra_url(&client.url);
+
+        if primary_local || primary_trusted {
+            client.connection_mode = if primary_local {
+                ZebraConnectionMode::DirectLocal
+            } else {
+                ZebraConnectionMode::DirectTrusted
+            };
+            return client;
+        }
+
+        let primary_is_remote = !primary_local;
         let any_fallback_remote = client.fallback_urls.iter().any(|u| !Self::is_local_url(u));
         let remote_rpc_possible = primary_is_remote || any_fallback_remote;
 
         let require_privacy = config.privacy_network.require_privacy_network;
-        // Local RPC should never be forced through Tor/I2P proxies.
-        // Keep privacy proxy policy for remote endpoints only.
         let selected_proxy = if remote_rpc_possible {
             Self::selected_proxy_from_config(config)
         } else {
@@ -302,11 +359,23 @@ impl ZebraClient {
         };
         client.privacy_proxy_url = selected_proxy.clone();
 
-        let timeout_secs = if Self::is_local_url(&client.url) {
-            10
-        } else {
-            30
-        };
+        let timeout_secs = if primary_local { 10 } else { 30 };
+        match selected_proxy.as_deref() {
+            Some(proxy_url) if proxy_url.to_ascii_lowercase().contains("socks") => {
+                client.connection_mode = ZebraConnectionMode::TorProxy;
+            }
+            Some(_) => {
+                client.connection_mode = ZebraConnectionMode::I2pProxy;
+            }
+            None if remote_rpc_possible && !require_privacy => {
+                client.connection_mode = ZebraConnectionMode::DirectRemote;
+            }
+            None if remote_rpc_possible => {
+                client.connection_mode = ZebraConnectionMode::Blocked;
+            }
+            _ => {}
+        }
+
         match selected_proxy {
             Some(proxy_url) => {
                 match Self::build_http_client(timeout_secs, Some(proxy_url.as_str())) {
@@ -318,9 +387,9 @@ impl ZebraClient {
                     Err(proxy_err) => {
                         if require_privacy && remote_rpc_possible {
                             client.block_remote_without_privacy = true;
+                            client.connection_mode = ZebraConnectionMode::Blocked;
                             client.privacy_block_reason = Some(format!(
-                                "Remote Zebra RPC blocked: privacy proxy configuration is invalid ({})",
-                                proxy_err
+                                "Remote Zebra RPC blocked: privacy proxy configuration is invalid ({proxy_err})"
                             ));
                         }
                     }
@@ -329,8 +398,11 @@ impl ZebraClient {
             None => {
                 if require_privacy && remote_rpc_possible {
                     client.block_remote_without_privacy = true;
+                    client.connection_mode = ZebraConnectionMode::Blocked;
                     client.privacy_block_reason = Some(
-                        "Remote Zebra RPC blocked: require_privacy_network=true but no Tor/I2P proxy is configured".to_string(),
+                        "Remote Zebra RPC blocked: require_privacy_network=true but no Tor/I2P proxy is configured. \
+Add the node to trusted_zebra_urls for operator infrastructure, or enable Tor."
+                            .to_string(),
                     );
                 }
             }
@@ -339,50 +411,7 @@ impl ZebraClient {
     }
 
     fn normalize_url(url: String) -> String {
-        let mut url = url.trim().to_string();
-
-        // Fix double dots in URLs (e.g., "zec..leoninedao.org" -> "zec.leoninedao.org")
-        url = url.replace("..", ".");
-
-        // Fix triple slashes (e.g., "https:///host" -> "https://host")
-        url = url.replace(":///", "://");
-
-        // Fix double slashes after protocol (e.g., "https:///host" -> "https://host")
-        if url.starts_with("http://") {
-            url = url.replace("http:///", "http://");
-        } else if url.starts_with("https://") {
-            url = url.replace("https:///", "https://");
-        }
-
-        if url.starts_with("http://") || url.starts_with("https://") {
-            // Keep the port if it's specified - don't remove it
-            // Only fix path slashes, preserve protocol and port
-            // The URL should be in format: https://host:port/path
-            // We want to preserve https:// and :port, only fix // in path
-
-            // Simple approach: if URL already has proper format, return as-is
-            // Only fix if there are obvious issues like triple slashes (already fixed above)
-            return url;
-        }
-
-        if url.contains(':') {
-            let parts: Vec<&str> = url.split(':').collect();
-            if parts.len() >= 2 {
-                if let Ok(port) = parts[1].parse::<u16>() {
-                    if port == 443 {
-                        return format!("https://{}", parts[0]);
-                    } else {
-                        return format!("http://{}", url);
-                    }
-                }
-            }
-        }
-
-        if Self::is_local_url(&url) {
-            format!("http://{}", url)
-        } else {
-            format!("https://{}", url)
-        }
+        normalize_zebra_rpc_url(&url)
     }
 
     pub async fn get_block(&self, height: u32) -> NozyResult<HashMap<String, Value>> {
@@ -1040,6 +1069,39 @@ pub struct OrchardTreeState {
     pub height: u32,
     pub anchor: [u8; 32],
     pub commitment_count: u64,
+}
+
+#[cfg(test)]
+mod connection_policy_tests {
+    use super::*;
+    use crate::config::{PrivacyNetworkConfig, WalletConfig};
+
+    #[test]
+    fn trusted_remote_url_bypasses_privacy_block() {
+        let mut config = WalletConfig::default();
+        config.zebra_url = "http://vps.example.com:8232".to_string();
+        config.trusted_zebra_urls = vec!["http://vps.example.com:8232".to_string()];
+        config.privacy_network = PrivacyNetworkConfig {
+            require_privacy_network: true,
+            tor_enabled: true,
+            ..PrivacyNetworkConfig::default()
+        };
+        let client = ZebraClient::from_config(&config);
+        assert_eq!(client.connection_mode(), ZebraConnectionMode::DirectTrusted);
+    }
+
+    #[test]
+    fn untrusted_remote_with_privacy_required_is_blocked() {
+        let mut config = WalletConfig::default();
+        config.zebra_url = "http://public.example.com:8232".to_string();
+        config.privacy_network = PrivacyNetworkConfig {
+            require_privacy_network: true,
+            tor_enabled: false,
+            ..PrivacyNetworkConfig::default()
+        };
+        let client = ZebraClient::from_config(&config);
+        assert_eq!(client.connection_mode(), ZebraConnectionMode::Blocked);
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- **Unified Zebra client:** `test-zebra`, sync, send, confirmations, and wallet status all use `ZebraClient::from_config_with_url()` — same privacy/Tor policy as real operations (fixes false-green API test).
- **`trusted_zebra_urls`:** operator-controlled allowlist for direct RPC when `require_privacy_network` is true (VPS/Leonine infra without disabling privacy globally).
- **Structured connect errors:** `PRIVACY_POLICY_BLOCKED`, `TOR_PROXY_UNREACHABLE`, `ZEBRA_RPC_UNREACHABLE` on sync connect phase and test-zebra failures.
- **`test-zebra` API** now returns JSON with `connection_mode`, `block_height`, and `code` on failure.

## Gilmore fix

Add VPS URL to config:

```json
{
  "zebra_url": "http://YOUR_VPS:8232",
  "trusted_zebra_urls": ["http://YOUR_VPS:8232"],
  "privacy_network": {
    "require_privacy_network": true,
    "tor_enabled": true
  }
}
```

Then `POST /api/config/test-zebra` and `/api/sync` use the same path (`direct_trusted`).

## Test plan

- [x] `cargo test connection_policy trusted_url --lib`
- [x] `cargo build -p nozywallet-api`
- [ ] Gilmore: add VPS to `trusted_zebra_urls`, verify test-zebra shows `connection_mode: direct_trusted` and sync succeeds
