### PR TITLE
fix(api): Orchard witness sync disconnected from scan status

### DIFF
--- a/api-server/src/handlers.rs
+++ b/api-server/src/handlers.rs
@@ -86,8 +86,36 @@ pub struct AddressResponse {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct BalanceResponse {
+    /// Legacy alias for confirmed shielded balance (`confirmed_zec`).
     pub balance_zec: f64,
+    /// Legacy alias for confirmed shielded balance in zatoshis.
     pub balance_zatoshis: u64,
+    pub confirmed_zec: f64,
+    pub confirmed_zatoshis: u64,
+    pub pending_zec: f64,
+    pub pending_zatoshis: u64,
+    /// Spendable balance (confirmed minus pending outbound sends).
+    pub available_zec: f64,
+    pub available_zatoshis: u64,
+    pub unspent_note_count: usize,
+}
+
+fn zats_to_zec(zat: u64) -> f64 {
+    zat as f64 / 100_000_000.0
+}
+
+fn balance_response_from_snapshot(snapshot: nozy::WalletBalanceSnapshot) -> BalanceResponse {
+    BalanceResponse {
+        balance_zec: zats_to_zec(snapshot.confirmed_zatoshis),
+        balance_zatoshis: snapshot.confirmed_zatoshis,
+        confirmed_zec: zats_to_zec(snapshot.confirmed_zatoshis),
+        confirmed_zatoshis: snapshot.confirmed_zatoshis,
+        pending_zec: zats_to_zec(snapshot.pending_zatoshis),
+        pending_zatoshis: snapshot.pending_zatoshis,
+        available_zec: zats_to_zec(snapshot.available_zatoshis),
+        available_zatoshis: snapshot.available_zatoshis,
+        unspent_note_count: snapshot.unspent_note_count,
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -384,23 +412,16 @@ pub async fn generate_address(
 
 pub async fn get_balance(
 ) -> Result<ResponseJson<BalanceResponse>, (StatusCode, ResponseJson<serde_json::Value>)> {
-    use nozy::{load_wallet_notes, wallet_unspent_balance_zatoshis};
-
-    let notes = load_wallet_notes().map_err(|e| {
+    let snapshot = nozy::wallet_balance_snapshot().map_err(|e| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,
             ResponseJson(serde_json::json!({
-                "error": format!("Failed to read notes: {}", e)
+                "error": format!("Failed to read wallet balance: {}", e)
             })),
         )
     })?;
 
-    let total_zat = wallet_unspent_balance_zatoshis(&notes);
-
-    Ok(ResponseJson(BalanceResponse {
-        balance_zec: total_zat as f64 / 100_000_000.0,
-        balance_zatoshis: total_zat,
-    }))
+    Ok(ResponseJson(balance_response_from_snapshot(snapshot)))
 }
 
 pub async fn sync_wallet(
@@ -421,17 +442,26 @@ pub async fn sync_wallet(
             )
         })?;
 
-    let mut options = WalletSyncOptions::api_default();
-    options.start_height = payload.start_height;
-    options.end_height = payload.end_height;
-    options.zebra_url = payload.zebra_url;
+    let scan_to_tip = payload.end_height.is_none();
+    let options = WalletSyncOptions {
+        start_height: payload.start_height,
+        end_height: payload.end_height,
+        scan_to_tip,
+        zebra_url: payload.zebra_url,
+        ..WalletSyncOptions::api_default()
+    };
 
     match sync_wallet_notes(wallet, options).await {
         Ok(result) => {
             let balance_zec = result.balance_zatoshis as f64 / 100_000_000.0;
             let message = if result.already_synced {
                 format!(
-                    "Wallet already synced to tip (height {}). Cached balance: {balance_zec:.8} ZEC",
+                    "Wallet synced to tip (height {}). Cached balance: {balance_zec:.8} ZEC",
+                    result.chain_tip
+                )
+            } else if result.blocks_scanned == 0 {
+                format!(
+                    "Witness catch-up in progress or incomplete (height {}). Cached balance: {balance_zec:.8} ZEC — repeat sync until ready for send",
                     result.chain_tip
                 )
             } else {
@@ -1327,28 +1357,47 @@ pub async fn search_address_book(
 
 #[derive(Debug, Serialize)]
 pub struct WalletStatusResponse {
+    /// Legacy alias for confirmed shielded balance (`confirmed_zec`).
     pub balance_zec: f64,
+    /// Legacy alias for confirmed shielded balance in zatoshis.
     pub balance_zatoshis: u64,
+    pub confirmed_zec: f64,
+    pub confirmed_zatoshis: u64,
+    pub pending_zec: f64,
+    pub pending_zatoshis: u64,
+    pub available_zec: f64,
+    pub available_zatoshis: u64,
+    pub unspent_note_count: usize,
     pub pending_transactions: usize,
     pub total_transactions: usize,
     pub last_sync_height: Option<u32>,
     pub current_block_height: Option<u32>,
     pub blocks_behind: Option<u32>,
+    pub witness_lag_blocks: u32,
+    pub witness_fresh_for_send: bool,
+    pub max_send_witness_lag_blocks: u32,
+    pub ready_for_send: bool,
 }
 
 pub async fn get_wallet_status(
 ) -> Result<ResponseJson<WalletStatusResponse>, (StatusCode, ResponseJson<serde_json::Value>)> {
     use nozy::{
-        load_config, load_wallet_notes, transaction_history::SentTransactionStorage,
-        wallet_unspent_balance_zatoshis, ZebraClient,
+        load_config, load_wallet_notes, max_serialized_witness_lag_blocks,
+        transaction_history::SentTransactionStorage, wallet_balance_snapshot, ZebraClient,
+        MAX_SEND_WITNESS_LAG_BLOCKS,
     };
 
     let config = load_config();
     let zebra_client = ZebraClient::from_config(&config);
 
-    let balance_zatoshis = load_wallet_notes()
-        .map(|notes| wallet_unspent_balance_zatoshis(&notes))
-        .unwrap_or(0);
+    let snapshot = wallet_balance_snapshot().map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            ResponseJson(serde_json::json!({
+                "error": format!("Failed to read wallet balance: {}", e)
+            })),
+        )
+    })?;
 
     let current_height = zebra_client.get_block_count().await.ok();
 
@@ -1370,14 +1419,36 @@ pub async fn get_wallet_status(
             None
         };
 
+    let witness_lag_blocks = current_height
+        .map(|tip| {
+            load_wallet_notes()
+                .map(|notes| max_serialized_witness_lag_blocks(&notes, tip))
+                .unwrap_or(0)
+        })
+        .unwrap_or(0);
+    let witness_fresh_for_send = witness_lag_blocks <= MAX_SEND_WITNESS_LAG_BLOCKS;
+    let scan_caught_up = blocks_behind == Some(0);
+    let ready_for_send = scan_caught_up && witness_fresh_for_send && current_height.is_some();
+
     Ok(ResponseJson(WalletStatusResponse {
-        balance_zec: balance_zatoshis as f64 / 100_000_000.0,
-        balance_zatoshis,
+        balance_zec: zats_to_zec(snapshot.confirmed_zatoshis),
+        balance_zatoshis: snapshot.confirmed_zatoshis,
+        confirmed_zec: zats_to_zec(snapshot.confirmed_zatoshis),
+        confirmed_zatoshis: snapshot.confirmed_zatoshis,
+        pending_zec: zats_to_zec(snapshot.pending_zatoshis),
+        pending_zatoshis: snapshot.pending_zatoshis,
+        available_zec: zats_to_zec(snapshot.available_zatoshis),
+        available_zatoshis: snapshot.available_zatoshis,
+        unspent_note_count: snapshot.unspent_note_count,
         pending_transactions: pending_count,
         total_transactions: total_count,
         last_sync_height: config.last_scan_height,
         current_block_height: current_height,
         blocks_behind,
+        witness_lag_blocks,
+        witness_fresh_for_send,
+        max_send_witness_lag_blocks: MAX_SEND_WITNESS_LAG_BLOCKS,
+        ready_for_send,
     }))
 }
 

--- a/src/orchard_tx.rs
+++ b/src/orchard_tx.rs
@@ -107,6 +107,40 @@ async fn advance_orchard_witness_from_zebra_blocks(
     Ok(())
 }
 
+/// Advance persisted note witnesses through chain tip (used when block scan is caught up but witnesses lag).
+pub async fn refresh_cached_witnesses_to_tip(
+    zebra: &ZebraClient,
+    notes: &mut [crate::notes::SerializableOrchardNote],
+    chain_tip: u32,
+) -> NozyResult<u32> {
+    use crate::orchard_tree_codec::orchard_incremental_witness_to_bytes;
+
+    let mut updated = 0u32;
+    for note in notes.iter_mut().filter(|n| !n.spent) {
+        let Some(ref witness_hex) = note.orchard_incremental_witness_hex else {
+            continue;
+        };
+        if witness_hex.is_empty() {
+            continue;
+        }
+        let stored_tip = note.orchard_witness_tip_height.unwrap_or(0);
+        if stored_tip >= chain_tip {
+            continue;
+        }
+        let bytes = hex::decode(witness_hex).map_err(|e| {
+            NozyError::InvalidOperation(format!("orchard_incremental_witness_hex decode: {e}"))
+        })?;
+        let mut witness = orchard_incremental_witness_from_bytes(&bytes)?;
+        advance_orchard_witness_from_zebra_blocks(&mut witness, zebra, stored_tip, chain_tip)
+            .await?;
+        note.orchard_incremental_witness_hex =
+            Some(hex::encode(orchard_incremental_witness_to_bytes(&witness)?));
+        note.orchard_witness_tip_height = Some(chain_tip);
+        updated += 1;
+    }
+    Ok(updated)
+}
+
 #[async_trait]
 impl OrchardWitnessProvider for ZebraJsonRpcOrchardWitnessProvider {
     async fn prepare_spend_anchor_and_path(

--- a/src/wallet_sync.rs
+++ b/src/wallet_sync.rs
@@ -3,12 +3,14 @@
 //! See [`docs/rfcs/WALLET_SYNC_UNIFIED_ARCHITECTURE.md`](../docs/rfcs/WALLET_SYNC_UNIFIED_ARCHITECTURE.md).
 
 use crate::config::{load_config, update_last_scan_height, WalletConfig};
-use crate::error::NozyError;
+use crate::error::{NozyError, NozyResult};
 use crate::hd_wallet::HDWallet;
 use crate::notes::{
     load_wallet_notes, merge_scanned_notes, save_wallet_notes, wallet_unspent_balance_zatoshis,
     NoteScanner,
 };
+use crate::orchard_tx::refresh_cached_witnesses_to_tip;
+use crate::send_readiness::{max_serialized_witness_lag_blocks, MAX_SEND_WITNESS_LAG_BLOCKS};
 use crate::zebra_integration::ZebraClient;
 use serde::{Deserialize, Serialize};
 
@@ -208,7 +210,9 @@ pub(crate) fn apply_empty_cache_backfill(
     if !notes_before.is_empty() {
         return;
     }
-    if options.start_height.is_some() || options.end_height.is_some() || options.scan_to_tip {
+    // User-scoped windows must not expand; plain `sync --to-tip` with an empty cache still needs
+    // a full backfill (otherwise only the incremental tail is scanned and balance stays zero).
+    if options.start_height.is_some() || options.end_height.is_some() {
         return;
     }
     range.scan_start = default_first_scan_start(config);
@@ -348,24 +352,12 @@ pub async fn sync_wallet_notes(
     let total_before = notes_before.len();
     let balance_before = wallet_unspent_balance_zatoshis(&notes_before);
 
-    // Already caught up: return cached balance without re-scanning or rewriting notes.json.
+    // Block scan caught up but Orchard witnesses may still lag — refresh witnesses to tip.
     if range.scan_start > range.scan_end {
-        let last_scan_height = config.last_scan_height.unwrap_or(range.chain_tip);
-        return Ok(WalletSyncResult {
-            balance_zatoshis: balance_before,
-            unspent_notes: notes_before.iter().filter(|n| !n.spent).count(),
-            total_notes: notes_before.len(),
-            new_notes_in_scan: 0,
-            scan_start: range.scan_start,
-            scan_end: range.scan_end,
-            chain_tip: range.chain_tip,
-            blocks_scanned: 0,
-            last_scan_height,
-            already_synced: true,
-        });
+        return finish_caught_up_sync(&zebra_client, notes_before, &range, &config, 0).await;
     }
 
-    let mut note_scanner = NoteScanner::new(wallet, zebra_client);
+    let mut note_scanner = NoteScanner::new(wallet, zebra_client.clone());
     let (scan_result, _spendable) = note_scanner
         .scan_notes(Some(range.scan_start), Some(range.scan_end))
         .await
@@ -382,6 +374,33 @@ pub async fn sync_wallet_notes(
 
     let mut cached_notes = notes_before;
     merge_scanned_notes(&mut cached_notes, &scan_result.notes);
+    if cached_notes.is_empty() && total_before > 0 {
+        return Err(WalletSyncError::with_range(
+            WalletSyncPhase::Persist,
+            NozyError::Storage(
+                "sync would overwrite a non-empty note cache with zero notes; refusing to persist. \
+                 Re-run with `nozy sync --start-height 3050000 --to-tip` to rebuild the cache."
+                    .to_string(),
+            ),
+            None,
+            scan_start,
+            scan_end,
+            chain_tip_opt,
+        ));
+    }
+    refresh_and_persist_witnesses(&zebra_client, &mut cached_notes, range.scan_end)
+        .await
+        .map_err(|e| {
+            WalletSyncError::with_range(
+                WalletSyncPhase::Scan,
+                e,
+                None,
+                scan_start,
+                scan_end,
+                chain_tip_opt,
+            )
+        })?;
+
     save_wallet_notes(&cached_notes).map_err(|e| {
         WalletSyncError::with_range(
             WalletSyncPhase::Persist,
@@ -404,13 +423,16 @@ pub async fn sync_wallet_notes(
         )
     })?;
 
-    let balance_zatoshis = wallet_unspent_balance_zatoshis(&cached_notes);
-    let unspent_notes = cached_notes.iter().filter(|n| !n.spent).count();
     let new_notes_in_scan = cached_notes.len().saturating_sub(total_before);
     let blocks_scanned = range
         .scan_end
         .saturating_sub(range.scan_start)
         .saturating_add(1);
+
+    cached_notes = reload_wallet_notes()?;
+
+    let balance_zatoshis = wallet_unspent_balance_zatoshis(&cached_notes);
+    let unspent_notes = cached_notes.iter().filter(|n| !n.spent).count();
 
     Ok(WalletSyncResult {
         balance_zatoshis,
@@ -423,6 +445,107 @@ pub async fn sync_wallet_notes(
         blocks_scanned,
         last_scan_height: range.scan_end,
         already_synced: false,
+    })
+}
+
+async fn refresh_and_persist_witnesses(
+    zebra_client: &ZebraClient,
+    notes: &mut [crate::notes::SerializableOrchardNote],
+    target_height: u32,
+) -> NozyResult<u32> {
+    let refreshed = refresh_cached_witnesses_to_tip(zebra_client, notes, target_height).await?;
+    Ok(refreshed)
+}
+
+/// Target height for witness catch-up when RPC scan is already at tip.
+///
+/// Large witness lag is advanced in [`DEFAULT_INCREMENTAL_BATCH`] chunks so API sync
+/// calls stay bounded instead of fetching thousands of blocks in one request.
+fn witness_catchup_target_height(
+    notes: &[crate::notes::SerializableOrchardNote],
+    chain_tip: u32,
+) -> u32 {
+    let lag = max_serialized_witness_lag_blocks(notes, chain_tip);
+    if lag == 0 {
+        return chain_tip;
+    }
+    let batch = DEFAULT_INCREMENTAL_BATCH.max(1);
+    if lag <= batch {
+        return chain_tip;
+    }
+    let min_stored = notes
+        .iter()
+        .filter(|n| {
+            !n.spent
+                && n.orchard_incremental_witness_hex
+                    .as_ref()
+                    .is_some_and(|h| !h.is_empty())
+        })
+        .map(|n| n.orchard_witness_tip_height.unwrap_or(0))
+        .min()
+        .unwrap_or(0);
+    min_stored.saturating_add(batch).min(chain_tip)
+}
+
+/// When RPC scan is caught up, advance Orchard witnesses on cached notes and report send readiness.
+async fn finish_caught_up_sync(
+    zebra_client: &ZebraClient,
+    notes_before: Vec<crate::notes::SerializableOrchardNote>,
+    range: &ScanRange,
+    config: &WalletConfig,
+    blocks_scanned: u32,
+) -> Result<WalletSyncResult, WalletSyncError> {
+    let witness_lag_before = max_serialized_witness_lag_blocks(&notes_before, range.chain_tip);
+    let mut notes_mut = notes_before;
+    if witness_lag_before > 0 {
+        let witness_target = witness_catchup_target_height(&notes_mut, range.chain_tip);
+        refresh_and_persist_witnesses(zebra_client, &mut notes_mut, witness_target)
+            .await
+            .map_err(|e| {
+                WalletSyncError::with_range(
+                    WalletSyncPhase::Scan,
+                    e,
+                    None,
+                    None,
+                    None,
+                    Some(range.chain_tip),
+                )
+            })?;
+        save_wallet_notes(&notes_mut).map_err(|e| {
+            WalletSyncError::with_range(
+                WalletSyncPhase::Persist,
+                e,
+                None,
+                None,
+                None,
+                Some(range.chain_tip),
+            )
+        })?;
+    }
+
+    let notes_after_repair = reload_wallet_notes()?;
+    let last_scan_height = config.last_scan_height.unwrap_or(range.chain_tip);
+    let witness_lag_after = max_serialized_witness_lag_blocks(&notes_after_repair, range.chain_tip);
+    let scan_caught_up = last_scan_height >= range.chain_tip;
+    let already_synced = scan_caught_up && witness_lag_after <= MAX_SEND_WITNESS_LAG_BLOCKS;
+
+    Ok(WalletSyncResult {
+        balance_zatoshis: wallet_unspent_balance_zatoshis(&notes_after_repair),
+        unspent_notes: notes_after_repair.iter().filter(|n| !n.spent).count(),
+        total_notes: notes_after_repair.len(),
+        new_notes_in_scan: 0,
+        scan_start: range.scan_start,
+        scan_end: range.scan_end,
+        chain_tip: range.chain_tip,
+        blocks_scanned,
+        last_scan_height,
+        already_synced,
+    })
+}
+
+fn reload_wallet_notes() -> Result<Vec<crate::notes::SerializableOrchardNote>, WalletSyncError> {
+    load_wallet_notes().map_err(|e| {
+        WalletSyncError::with_range(WalletSyncPhase::LoadNotes, e, None, None, None, None)
     })
 }
 
@@ -493,11 +616,68 @@ mod tests {
     }
 
     #[test]
+    fn witness_catchup_batches_large_lag() {
+        use crate::notes::SerializableOrchardNote;
+
+        let notes = vec![SerializableOrchardNote {
+            note_bytes: vec![1],
+            value: 250_000,
+            address_bytes: vec![0; 43],
+            block_height: 3_379_050,
+            nullifier_bytes: vec![2; 32],
+            txid: "abc".to_string(),
+            spent: false,
+            memo: vec![],
+            orchard_incremental_witness_hex: Some("ab".to_string()),
+            orchard_witness_tip_height: Some(3_379_050),
+            rho_bytes: None,
+            rseed_bytes: None,
+        }];
+        let chain_tip = 3_389_822;
+        let target = witness_catchup_target_height(&notes, chain_tip);
+        assert_eq!(target, 3_379_050 + DEFAULT_INCREMENTAL_BATCH);
+        assert!(target < chain_tip);
+    }
+
+    #[test]
+    fn witness_catchup_reaches_tip_when_lag_within_batch() {
+        use crate::notes::SerializableOrchardNote;
+
+        let notes = vec![SerializableOrchardNote {
+            note_bytes: vec![1],
+            value: 250_000,
+            address_bytes: vec![0; 43],
+            block_height: 3_389_500,
+            nullifier_bytes: vec![2; 32],
+            txid: "abc".to_string(),
+            spent: false,
+            memo: vec![],
+            orchard_incremental_witness_hex: Some("ab".to_string()),
+            orchard_witness_tip_height: Some(3_389_500),
+            rho_bytes: None,
+            rseed_bytes: None,
+        }];
+        let chain_tip = 3_389_822;
+        assert_eq!(witness_catchup_target_height(&notes, chain_tip), chain_tip);
+    }
+
+    #[test]
     fn empty_cache_backfills_when_checkpoint_at_tip() {
         let config = test_config(Some(3_380_000), "mainnet");
         let opts = WalletSyncOptions::default();
         let mut range = resolve_scan_range(&config, &opts, 3_380_000).unwrap();
         assert!(range.scan_start > range.scan_end);
+        apply_empty_cache_backfill(&mut range, &config, &opts, &[]);
+        assert_eq!(range.scan_start, MAINNET_DEFAULT_SCAN_START);
+        assert_eq!(range.scan_end, 3_380_000);
+    }
+
+    #[test]
+    fn empty_cache_to_tip_backfills_from_mainnet_default() {
+        let config = test_config(Some(3_380_000), "mainnet");
+        let opts = WalletSyncOptions::to_tip();
+        let mut range = resolve_scan_range(&config, &opts, 3_380_000).unwrap();
+        assert_eq!(range.scan_end, 3_380_000);
         apply_empty_cache_backfill(&mut range, &config, &opts, &[]);
         assert_eq!(range.scan_start, MAINNET_DEFAULT_SCAN_START);
         assert_eq!(range.scan_end, 3_380_000);


### PR DESCRIPTION
## Summary
- Refresh Orchard witnesses on all cached notes after every sync (not only notes discovered in the current scan range).
- When RPC scan is already at tip, run batched witness catch-up (1000 blocks per `/api/sync` call) instead of skipping it.
- Extend `/api/wallet/status` with `witness_lag_blocks`, `witness_fresh_for_send`, and `ready_for_send` so operators are not misled by `blocks_behind: 0` alone.
- Align API sync with desktop: `scan_to_tip` when `end_height` is omitted.

## Test plan
- [ ] Rebuild and restart `nozywallet-api`
- [ ] Confirm `/api/wallet/status` shows witness lag when scan is caught up but witnesses are stale
- [ ] Run `POST /api/sync` repeatedly until `ready_for_send: true`
- [ ] Confirm `POST /api/transaction/send` succeeds after witness catch-up

## AI disclosure
Implementation drafted with Cursor (Claude); human author responsible for review.