### PR TITLE
fix(landing): repair blank GitHub Pages site and refresh downloads

### DIFF
--- a/landing/index.html
+++ b/landing/index.html
@@ -27,7 +27,7 @@
       NozyWallet - Privacy by Default | Monero-Level Privacy, Zcash Speed
     </title>
   </head>
-  <body>
+  <body style="margin:0;background:#ffffff;color:#18181b;">
     <div id="root"></div>
     <script
       type="module"

--- a/landing/package-lock.json
+++ b/landing/package-lock.json
@@ -8,12 +8,11 @@
       "name": "nozywallet",
       "version": "0.0.0",
       "dependencies": {
-        "@emnapi/runtime": "1.11.2",
         "@solar-icons/react": "^1.0.1",
         "@tailwindcss/vite": "^4.3.2",
         "@vercel/analytics": "^1.6.1",
         "react": "19.2.7",
-        "react-dom": "19.2.6",
+        "react-dom": "19.2.7",
         "react-router-dom": "^7.12.0",
         "tailwindcss": "^4.3.2"
       },
@@ -69,6 +68,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -276,27 +276,6 @@
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
-      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
-      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -892,12 +871,6 @@
         "tailwindcss": "4.3.2"
       }
     },
-    "node_modules/@tailwindcss/node/node_modules/tailwindcss": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.1.tgz",
-      "integrity": "sha512-hk+TB1m+K8CYNrP6rjQaq/Y+4Zylwpa87mLYBKCunwnnQ9p+fHb7kmSfGqyEJoxF/O6CDyABWVFEafNSYKll+Q==",
-      "license": "MIT"
-    },
     "node_modules/@tailwindcss/oxide": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.2.tgz",
@@ -1008,9 +981,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1026,9 +996,6 @@
       "integrity": "sha512-J5Nuk0uZQIiMTJj3LEx4sAA9tMFUoXQZFv1J6An+QGYe53HKRJuFDi0rpq/tuouCZeAbOBY3kQ6g8qeD4TUjtA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1046,9 +1013,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1064,9 +1028,6 @@
       "integrity": "sha512-cixpqbh2toJDmkuCRI68nXA8ZxNmdK9Y+9v5h3MC3ZQKy/0BO8AWzlkWyRM7JAFSGBlfig4YVTPsK6MVgqz1uw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1104,25 +1065,6 @@
       },
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.11.1",
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.11.1",
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
@@ -1212,12 +1154,6 @@
         "vite": "^5.2.0 || ^6 || ^7 || ^8"
       }
     },
-    "node_modules/@tailwindcss/vite/node_modules/tailwindcss": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.1.tgz",
-      "integrity": "sha512-hk+TB1m+K8CYNrP6rjQaq/Y+4Zylwpa87mLYBKCunwnnQ9p+fHb7kmSfGqyEJoxF/O6CDyABWVFEafNSYKll+Q==",
-      "license": "MIT"
-    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
@@ -1255,6 +1191,7 @@
       "integrity": "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~8.3.0"
       }
@@ -1265,6 +1202,7 @@
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1324,6 +1262,7 @@
       "integrity": "sha512-dzHeT2gySzZtLDsuqxU9AkYgIsQoHAHtRBpOqM+Ofzx1Bwrd2RcCjQJ+6iQbsHOIR6NS33bF2W1k3blN1zLDrA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.62.0",
         "@typescript-eslint/types": "8.62.0",
@@ -1631,6 +1570,7 @@
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1716,6 +1656,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.38",
         "caniuse-lite": "^1.0.30001799",
@@ -1883,6 +1824,7 @@
       "integrity": "sha512-6lVbcqSodALYo+4ELD0heG6lFiFxnLMuLkiMi2qV8LMp54N8tE8FT1GMH+ev4Ti00nFjNze2+Su6DsV5OQW3Dg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "workspaces": [
         "packages/*"
       ],
@@ -3040,6 +2982,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3100,20 +3043,22 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
       "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.6",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
-      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.6"
+        "react": "^19.2.7"
       }
     },
     "node_modules/react-router": {
@@ -3335,6 +3280,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3420,6 +3366,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.3.tgz",
       "integrity": "sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -3551,6 +3498,7 @@
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/landing/package.json
+++ b/landing/package.json
@@ -15,12 +15,13 @@
     "@tailwindcss/vite": "^4.3.2",
     "@vercel/analytics": "^1.6.1",
     "react": "19.2.7",
-    "react-dom": "19.2.6",
+    "react-dom": "19.2.7",
     "react-router-dom": "^7.12.0",
     "tailwindcss": "^4.3.2"
   },
   "overrides": {
-    "react-dom": "19.2.6"
+    "react": "19.2.7",
+    "react-dom": "19.2.7"
   },
   "optionalDependencies": {
     "@emnapi/core": "1.11.1",

--- a/landing/src/components/DownloadSection.tsx
+++ b/landing/src/components/DownloadSection.tsx
@@ -1,4 +1,8 @@
-import { DOWNLOAD_URLS, REPO_RELEASES_LATEST } from "../lib/downloads";
+import {
+  DOWNLOAD_URLS,
+  DESKTOP_DOWNLOAD_URLS,
+  REPO_RELEASES_LATEST,
+} from "../lib/downloads";
 import { PATHS } from "../lib/links";
 
 const card =
@@ -15,18 +19,24 @@ const DownloadSection = () => {
           Download NozyWallet
         </h2>
         <p className="text-zinc-600 text-center max-w-2xl mx-auto mb-12">
-          <strong>Production-ready today:</strong> the{" "}
-          <strong className="text-zinc-800">CLI wallet</strong> (<code className="text-xs bg-zinc-100 px-1 rounded">nozy</code>
-          ). Run it with your own <strong>zebrad</strong> and <strong>lightwalletd</strong>.
-          Desktop, browser extension, and mobile apps are in active development — contributors can build from source on GitHub.
+          <strong>CLI Lite</strong> is production-ready for mainnet.{" "}
+          <strong>Desktop beta</strong> is available for early testers (Ironwood WIP).
+          Extension and mobile stay contributor / roadmap for now.
         </p>
 
         <div className={`${card} mb-6 border-yellow-200 bg-yellow-50/30`}>
-          <h3 className="font-semibold text-lg text-zinc-900 mb-1">
-            Command-line wallet (production)
-          </h3>
+          <div className="flex flex-wrap items-center gap-2 mb-2">
+            <h3 className="font-semibold text-lg text-zinc-900">
+              CLI Lite — Teriyaki Hot
+            </h3>
+            <span className="text-xs font-semibold uppercase tracking-wide px-2 py-0.5 rounded-full border bg-emerald-500/10 text-emerald-800 border-emerald-500/25">
+              Mainnet ready
+            </span>
+          </div>
           <p className="text-sm text-zinc-600 mb-4">
-            Single binary per OS. On Linux / macOS run{" "}
+            Orchard-first <code className="text-xs bg-zinc-100 px-1 rounded">nozy</code> binary.
+            Pair with your own <strong>zebrad</strong> + <strong>lightwalletd</strong>.
+            On Linux / macOS run{" "}
             <code className="text-xs bg-zinc-100 px-1 rounded">chmod +x</code> after download.
           </p>
           <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 mb-3">
@@ -64,35 +74,61 @@ const DownloadSection = () => {
           </p>
         </div>
 
+        <div className={`${card} mb-6 border-amber-200 bg-amber-50/40`}>
+          <div className="flex flex-wrap items-center gap-2 mb-2">
+            <h3 className="font-semibold text-lg text-zinc-900">
+              Desktop — Hot Lemon beta.2
+            </h3>
+            <span className="text-xs font-semibold uppercase tracking-wide px-2 py-0.5 rounded-full border bg-amber-500/10 text-amber-900 border-amber-500/25">
+              Beta · Ironwood WIP
+            </span>
+          </div>
+          <p className="text-sm text-zinc-600 mb-4">
+            Tauri GUI for operators and early testers. GA waits until Ironwood is official.
+            Prefer CLI Lite for production mainnet today.
+          </p>
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-2 mb-3">
+            <a
+              href={DESKTOP_DOWNLOAD_URLS.windows}
+              className="text-center rounded-lg bg-zinc-900 hover:bg-zinc-800 text-white font-semibold py-2.5 text-sm"
+            >
+              Windows installer
+            </a>
+            <a
+              href={DESKTOP_DOWNLOAD_URLS.macArm}
+              className="text-center rounded-lg bg-zinc-900 hover:bg-zinc-800 text-white font-semibold py-2.5 text-sm"
+            >
+              macOS ARM
+            </a>
+            <a
+              href={DESKTOP_DOWNLOAD_URLS.linux}
+              className="text-center rounded-lg bg-zinc-900 hover:bg-zinc-800 text-white font-semibold py-2.5 text-sm"
+            >
+              Linux x86_64
+            </a>
+          </div>
+          <a
+            href={DESKTOP_DOWNLOAD_URLS.releasePage}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-xs font-medium text-yellow-700 hover:underline"
+          >
+            Desktop beta release notes &amp; checksums →
+          </a>
+        </div>
+
         <div className="grid md:grid-cols-2 gap-6 mb-6">
           <div className={`${card} border-dashed border-zinc-300 bg-zinc-50/80`}>
             <h3 className="font-semibold text-lg text-zinc-900 mb-1">
-              Desktop app (in development)
+              Browser extension (preview)
             </h3>
             <p className="text-sm text-zinc-600 mb-4">
-              Tauri GUI under <code className="text-xs bg-zinc-100 px-1 rounded">desktop-client/</code>.
-              Not promoted for end-user download until production-ready. Use the CLI for mainnet today.
+              MV3 + WASM wallet in{" "}
+              <code className="text-xs bg-zinc-100 px-1 rounded">browser-extension/</code>.
+              Contributor builds ship with desktop beta releases; companion API required.
             </p>
             <a
-              href="https://github.com/LEONINE-DAO/Nozy-wallet/tree/master/desktop-client"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex w-full items-center justify-center rounded-xl border border-zinc-300 bg-white hover:bg-zinc-100 text-zinc-800 font-medium py-3 transition-colors"
-            >
-              Build from source on GitHub →
-            </a>
-          </div>
-
-          <div className={`${card} border-dashed border-zinc-300 bg-zinc-50/80`}>
-            <h3 className="font-semibold text-lg text-zinc-900 mb-1">
-              Browser extension (in development)
-            </h3>
-            <p className="text-sm text-zinc-600 mb-4">
-              MV3 + WASM wallet in <code className="text-xs bg-zinc-100 px-1 rounded">browser-extension/</code>.
-              Requires companion API for compact sync — contributor preview only for now.
-            </p>
-            <a
-              href="https://github.com/LEONINE-DAO/Nozy-wallet/tree/master/browser-extension"
+              href={PATHS.extension}
               target="_blank"
               rel="noopener noreferrer"
               className="inline-flex w-full items-center justify-center rounded-xl border border-zinc-300 bg-white hover:bg-zinc-100 text-zinc-800 font-medium py-3 transition-colors"
@@ -100,42 +136,23 @@ const DownloadSection = () => {
               Extension docs on GitHub →
             </a>
           </div>
-        </div>
 
-        <div className={`${card} mb-6 border-dashed border-2 border-zinc-300 bg-zinc-50/80`}>
-          <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
-            <div>
-              <h3 className="font-semibold text-lg text-zinc-900 mb-1">
-                iPhone &amp; Android (coming soon)
-              </h3>
-              <p className="text-sm text-zinc-600 max-w-xl">
-                Native apps for <strong className="text-zinc-800">App Store</strong> and{" "}
-                <strong className="text-zinc-800">Google Play</strong> are on the roadmap. Until then,
-                use the <strong>CLI</strong> on a computer you control.
-              </p>
-            </div>
-            <div className="flex flex-col sm:items-end gap-2 shrink-0">
-              <span
-                className="inline-flex items-center justify-center rounded-xl border border-zinc-300 bg-white px-4 py-2.5 text-sm font-medium text-zinc-400 cursor-not-allowed"
-                title="Not published yet"
-              >
-                App Store — soon
-              </span>
-              <span
-                className="inline-flex items-center justify-center rounded-xl border border-zinc-300 bg-white px-4 py-2.5 text-sm font-medium text-zinc-400 cursor-not-allowed"
-                title="Not published yet"
-              >
-                Google Play — soon
-              </span>
-              <a
-                href={PATHS.enhancementRoadmap}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-sm font-medium text-yellow-700 hover:underline text-center sm:text-right"
-              >
-                Product roadmap on GitHub →
-              </a>
-            </div>
+          <div className={`${card} border-dashed border-zinc-300 bg-zinc-50/80`}>
+            <h3 className="font-semibold text-lg text-zinc-900 mb-1">
+              iPhone &amp; Android (coming soon)
+            </h3>
+            <p className="text-sm text-zinc-600 mb-4">
+              Expo companion for App Store / Play is on the roadmap. Until then, use CLI Lite
+              or Desktop beta on a machine you control.
+            </p>
+            <a
+              href={PATHS.mobile}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex w-full items-center justify-center rounded-xl border border-zinc-300 bg-white hover:bg-zinc-100 text-zinc-800 font-medium py-3 transition-colors"
+            >
+              Mobile repo on GitHub →
+            </a>
           </div>
         </div>
 
@@ -146,7 +163,7 @@ const DownloadSection = () => {
             rel="noopener noreferrer"
             className="text-yellow-700 font-medium hover:underline"
           >
-            Browse CLI release assets &amp; checksums →
+            Browse all release assets &amp; checksums →
           </a>
         </p>
       </div>

--- a/landing/src/components/Header.tsx
+++ b/landing/src/components/Header.tsx
@@ -26,7 +26,8 @@ const Header = () => {
       const element = document.getElementById(id);
       if (element) {
         element.scrollIntoView({ behavior: "smooth" });
-        window.history.pushState(null, "", `/#${id}`);
+        const base = (import.meta.env.BASE_URL || "/").replace(/\/$/, "");
+        window.history.pushState(null, "", `${base}/#${id}`);
       }
     } else {
       navigate("/", { state: { scrollTo: id } });

--- a/landing/src/components/Hero.tsx
+++ b/landing/src/components/Hero.tsx
@@ -17,7 +17,7 @@ const Hero = () => {
       <div className="max-w-7xl mx-auto px-6 text-center relative z-10">
         <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-yellow-500/10 border border-yellow-500/20 text-xs font-medium text-yellow-700 mb-8 animate-fade-in-up">
           <ShieldKeyholeMinimalistic size={14} />
-          <span>Privacy super wallet · ZEC first</span>
+          <span>CLI Lite · Desktop beta · Orchard ZEC</span>
         </div>
 
         <h1 className="text-5xl lg:text-7xl font-bold tracking-tight mb-4 leading-tight text-zinc-900">
@@ -30,27 +30,26 @@ const Hero = () => {
         </p>
 
         <p className="max-w-2xl mx-auto text-lg text-zinc-600 mb-10 leading-relaxed">
-          NozyWallet is a self-custodial privacy wallet — community-shaped, built only for
-          shielded assets. Orchard ZEC is supported today; more privacy chains join as modules, not
-          noise.
+          NozyWallet is a self-custodial privacy wallet — Orchard ZEC first, shielded by default.
+          CLI Lite is mainnet-ready; Desktop beta.2 is out for early testers while Ironwood lands.
         </p>
 
         <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
           <a
-            href="#products"
-            className="w-full sm:w-auto px-8 py-4 bg-yellow-500 hover:bg-yellow-400 text-white rounded-xl font-bold transition-all shadow-lg shadow-yellow-500/20 flex items-center justify-center gap-2"
-          >
-            Choose your surface
-          </a>
-          <a
             href="#download"
-            className="w-full sm:w-auto px-8 py-4 bg-zinc-900 hover:bg-zinc-800 text-white rounded-xl font-semibold transition-all shadow-md flex items-center justify-center gap-2 group"
+            className="w-full sm:w-auto px-8 py-4 bg-yellow-500 hover:bg-yellow-400 text-white rounded-xl font-bold transition-all shadow-lg shadow-yellow-500/20 flex items-center justify-center gap-2 group"
           >
             <AltArrowDown
               size={20}
               className="group-hover:translate-y-1 transition-transform"
             />
-            Get CLI (mainnet)
+            Download CLI Lite
+          </a>
+          <a
+            href="#products"
+            className="w-full sm:w-auto px-8 py-4 bg-zinc-900 hover:bg-zinc-800 text-white rounded-xl font-semibold transition-all shadow-md flex items-center justify-center gap-2"
+          >
+            See all surfaces
           </a>
           <a
             href="https://leonine-dao.github.io/Nozy-wallet/book/"

--- a/landing/src/components/ProductSurfaces.tsx
+++ b/landing/src/components/ProductSurfaces.tsx
@@ -34,6 +34,34 @@ const statusStyles: Record<Status, string> = {
 const surfaces: Surface[] = [
   {
     icon: Bolt,
+    title: "CLI Lite",
+    tagline: "Production-ready shielded ZEC on your own Zebrad + lightwalletd.",
+    status: "live",
+    statusLabel: "Mainnet ready",
+    bullets: [
+      "Orchard-first sends and sync (Nozy Lite)",
+      "ZIP-317 fees, NU6.2 mainnet",
+      "Ops helpers: health, status --json, optional Nym broadcast",
+    ],
+    primary: { label: "Get CLI Lite", href: "#download" },
+    secondary: { label: "Latest release", href: REPO_RELEASES },
+  },
+  {
+    icon: LockPassword,
+    title: "Desktop",
+    tagline: "Tauri GUI — Hot Lemon beta with Ironwood readiness tooling.",
+    status: "preview",
+    statusLabel: "Beta.2",
+    bullets: [
+      "Windows / macOS / Linux builds published",
+      "Ironwood migrate / split / broadcast UI",
+      "GA deferred until Ironwood is official",
+    ],
+    primary: { label: "Download desktop beta", href: "#download" },
+    secondary: { label: "Desktop source", href: PATHS.desktop },
+  },
+  {
+    icon: ShieldCheck,
     title: "Browser extension",
     tagline: "The community-shaped path — privacy-first, in your browser.",
     status: "preview",
@@ -41,7 +69,7 @@ const surfaces: Surface[] = [
     bullets: [
       "MV3 + WASM Orchard wallet",
       "Compact sync via local companion API",
-      "Future home of the full web super-wallet UX",
+      "Zips ship alongside desktop beta releases",
     ],
     primary: { label: "Extension docs", href: PATHS.extension, external: true },
     secondary: { label: "Companion setup", href: PATHS.extensionCompanion },
@@ -59,33 +87,6 @@ const surfaces: Surface[] = [
     ],
     primary: { label: "Web app plan", href: PATHS.webApp, external: true },
     secondary: { label: "Enhancement roadmap", href: PATHS.enhancementRoadmap },
-  },
-  {
-    icon: ShieldCheck,
-    title: "CLI wallet",
-    tagline: "Production-ready shielded ZEC on your own Zebrad + lightwalletd.",
-    status: "live",
-    statusLabel: "Mainnet ready",
-    bullets: [
-      "Orchard-first sends and sync",
-      "ZIP-317 fees, NU6.2 mainnet",
-      "Best for operators and power users today",
-    ],
-    primary: { label: "Get CLI", href: "#download" },
-    secondary: { label: "Latest release", href: REPO_RELEASES },
-  },
-  {
-    icon: LockPassword,
-    title: "Desktop",
-    tagline: "Tauri app for node stacks, debugging, and heavy sync.",
-    status: "preview",
-    statusLabel: "In development",
-    bullets: [
-      "Zebrad + lightwalletd from one place",
-      "Operator and developer workflows",
-      "Build from source until production release",
-    ],
-    primary: { label: "Build desktop", href: PATHS.desktop, external: true },
   },
   {
     icon: Download,
@@ -183,8 +184,8 @@ const ProductSurfaces = () => {
           <p className="text-zinc-600 text-lg leading-relaxed">
             NozyWallet is community-shaped for privacy-native daily use: extension and web app for
             daily flows, CLI and desktop for operators, mobile when you are on the go.{" "}
-            <strong className="text-zinc-800 font-semibold">Shielded ZEC is live now</strong> on
-            the CLI; other privacy chains ship as modules when ready.
+            <strong className="text-zinc-800 font-semibold">CLI Lite is live for mainnet</strong>;
+            Desktop beta.2 is out for early testers. Other privacy chains ship as modules when ready.
           </p>
         </div>
 

--- a/landing/src/lib/downloads.ts
+++ b/landing/src/lib/downloads.ts
@@ -1,20 +1,37 @@
 /**
- * CLI binaries ship with every release tag. Other surfaces (desktop, extension)
- * are in development and are not linked for end-user download yet.
+ * Download URLs for GitHub Releases.
+ * CLI assets ship on the latest (non-prerelease) tag via /releases/latest.
+ * Desktop beta is a prerelease — pin the tag so links stay stable.
  */
 export const REPO_RELEASES_LATEST =
   "https://github.com/LEONINE-DAO/Nozy-wallet/releases/latest";
 
-/** Direct asset URL when you know the file exists on the current latest release. */
+export const DESKTOP_BETA_TAG = "desktop-v1.1.0-beta2-Hot-lemon";
+export const DESKTOP_BETA_RELEASE =
+  `https://github.com/LEONINE-DAO/Nozy-wallet/releases/tag/${DESKTOP_BETA_TAG}`;
+
+/** Direct asset URL on the current latest (non-prerelease) release. */
 export function releaseAsset(filename: string): string {
   return `${REPO_RELEASES_LATEST}/download/${encodeURIComponent(filename)}`;
 }
 
-/** Production-ready CLI assets (attached on every tag). */
+export function desktopBetaAsset(filename: string): string {
+  return `https://github.com/LEONINE-DAO/Nozy-wallet/releases/download/${DESKTOP_BETA_TAG}/${encodeURIComponent(filename)}`;
+}
+
+/** Production CLI assets (attached on every CLI tag). */
 export const DOWNLOAD_URLS = {
   cliWindows: releaseAsset("nozy-windows.exe"),
   cliLinux: releaseAsset("nozy-linux"),
   cliMacIntel: releaseAsset("nozy-macos-intel"),
   cliMacArm: releaseAsset("nozy-macos-arm"),
   hashes: releaseAsset("HASHES.txt"),
+} as const;
+
+/** Desktop beta.2 installer / binaries (prerelease). */
+export const DESKTOP_DOWNLOAD_URLS = {
+  windows: desktopBetaAsset("nozy-desktop-windows-x86_64-installer.exe"),
+  linux: desktopBetaAsset("nozy-desktop-linux-x86_64.tar.gz"),
+  macArm: desktopBetaAsset("nozy-desktop-macos-aarch64.tar.gz"),
+  releasePage: DESKTOP_BETA_RELEASE,
 } as const;


### PR DESCRIPTION
## Summary
- Fix blank white page caused by **react 19.2.7 / react-dom 19.2.6 mismatch** (React error #527 → empty `#root`)
- Align both to **19.2.7** with overrides
- Refresh copy + downloads for **CLI Lite (Teriyaki Hot)** and **Desktop beta.2 (Hot Lemon)**
- Fix header hash links to respect the `/Nozy-wallet/` base path

## Test plan
- [x] `npm run build` in `landing/`
- [ ] Pages deploy succeeds
- [ ] https://leonine-dao.github.io/Nozy-wallet/ renders content (not blank)