### PR TITLE
fix(landing): sync lockfile so Pages npm ci works

### DIFF
--- a/landing/package-lock.json
+++ b/landing/package-lock.json
@@ -33,7 +33,7 @@
         "vite": "^8.1.3"
       },
       "optionalDependencies": {
-        "@emnapi/core": "1.11.1",
+        "@emnapi/core": "1.11.2",
         "@emnapi/runtime": "1.11.2"
       }
     },
@@ -793,6 +793,17 @@
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {

--- a/landing/package.json
+++ b/landing/package.json
@@ -24,7 +24,7 @@
     "react-dom": "19.2.7"
   },
   "optionalDependencies": {
-    "@emnapi/core": "1.11.1",
+    "@emnapi/core": "1.11.2",
     "@emnapi/runtime": "1.11.2"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
Pages deploy failed: `npm ci` out of sync (missing `@emnapi/core` / `@emnapi/runtime` in lockfile). Regenerated lock after aligning optionalDeps to 1.11.2.

## Test plan
- [x] `npm ci` + `npm run build` in `landing/`
- [ ] Pages deploy succeeds and site renders