### PR TITLE
Add Zakura full-node support for Zakura node runners

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -60,6 +60,7 @@
 
 - [Network Configuration](advanced/network-config.md)
 - [Zebra Node Setup](advanced/zebra-node.md)
+- [Zakura Node Setup](advanced/zakura-node.md)
 - [Proving Parameters](advanced/proving-parameters.md)
 - [API Server Setup](advanced/api-server.md)
 - [Secret Network (ZEC + Secret from One Seed)](advanced/secret-network.md)

--- a/book/src/advanced/network-config.md
+++ b/book/src/advanced/network-config.md
@@ -23,7 +23,7 @@ Common fields:
 
 | Variable | Overrides |
 |----------|-----------|
-| `ZEBRA_RPC_URL` | Primary Zebrad RPC URL |
+| `ZEBRA_RPC_URL` | Primary full-node RPC URL (Zebrad or Zakura) |
 | `LIGHTWALLETD_GRPC` | lightwalletd gRPC endpoint |
 
 ## CLI
@@ -42,7 +42,7 @@ nozy config --use-remote http://vps:8232
 
 ## Backend selection
 
-Default: **Zebrad** JSON-RPC. Optional Crosslink backend via `nozy config` flags — see `nozy config --help` in your build.
+Default: **Zebrad** or **Zakura** JSON-RPC (Zebra-fork compatible). Optional Crosslink backend via `nozy config` flags — see `nozy config --help` in your build.
 
 ## UTF-8 BOM note
 
@@ -55,4 +55,6 @@ Configured `zebra_url` is trusted for broadcast and chain tip. Optional `trusted
 ## Related
 
 - [Zebra Node Setup](zebra-node.md)
-- [Connectivity reference](../../../docs/reference/ZEBRAD_NOZYWALLET_CONNECTIVITY.md)
+- [Zakura Node Setup](zakura-node.md)
+- [Zebrad connectivity reference](../../../docs/reference/ZEBRAD_NOZYWALLET_CONNECTIVITY.md)
+- [Zakura connectivity reference](../../../docs/reference/ZAKURA_NOZYWALLET_CONNECTIVITY.md)

--- a/book/src/advanced/zakura-node.md
+++ b/book/src/advanced/zakura-node.md
@@ -1,0 +1,52 @@
+# Zakura Node Setup
+
+NozyWallet works with **[Zakura](https://zakura.com/)** — a Zebra-fork full node — using the **same config** as Zebrad. You do **not** need Zakura’s zcashd compatibility mode.
+
+Full operator guide: **[Zakura ↔ NozyWallet connectivity](../../../docs/reference/ZAKURA_NOZYWALLET_CONNECTIVITY.md)**.
+
+---
+
+## Quick setup
+
+### 1. Configure Zakurad
+
+```toml
+# ~/.config/zakurad.toml
+
+[rpc]
+listen_addr = "127.0.0.1:8232"
+enable_cookie_auth = false   # lightwalletd + local dev
+```
+
+```bash
+zakurad start
+```
+
+### 2. lightwalletd
+
+Point [lightwalletd](https://github.com/zcash/lightwalletd) at Zakura RPC (`127.0.0.1:8232`). See Zakura’s [lightwalletd book chapter](https://github.com/zakura-core/zakura/blob/v1.0.0/book/src/user/lightwalletd.md).
+
+### 3. Point NozyWallet
+
+```bash
+nozy config --set-zebra-url http://127.0.0.1:8232
+nozy test-zebra    # detects Zakura + probes z_gettreestate
+nozy sync --to-tip
+```
+
+---
+
+## Zebrad or Zakura?
+
+| Node | When to use |
+|------|-------------|
+| **Zebrad** | Zcash Foundation default; well-trodden with NozyWallet CI |
+| **Zakura** | Faster sync, snapshots, pruned nodes; Ironwood from Project Tachyon / Valar |
+
+Both use port **8232** (mainnet) and the same `zebra_url` setting.
+
+---
+
+## Troubleshooting
+
+See the [connectivity guide](../../../docs/reference/ZAKURA_NOZYWALLET_CONNECTIVITY.md) and [`ZEBRAD_SHIELDED_SEND_LIMIT.md`](../../../ZEBRAD_SHIELDED_SEND_LIMIT.md).

--- a/book/src/advanced/zebra-node.md
+++ b/book/src/advanced/zebra-node.md
@@ -1,8 +1,8 @@
 # Zebra Node Setup
 
-NozyWallet is an Orchard wallet — **not** a Zcash consensus node. For sync, broadcast, and treestate you need a running **[Zebrad](https://github.com/ZcashFoundation/zebra)** instance with JSON-RPC enabled.
+NozyWallet is an Orchard wallet — **not** a Zcash consensus node. For sync, broadcast, and treestate you need a running **[Zebrad](https://github.com/ZcashFoundation/zebra)** or **[Zakura](https://zakura.com/)** instance with JSON-RPC enabled.
 
-For a full operator guide (lectures, papers, Windows + WSL checklists), see **[Zebrad ↔ NozyWallet connectivity](../../../docs/reference/ZEBRAD_NOZYWALLET_CONNECTIVITY.md)** in the repo docs.
+For a full operator guide (lectures, papers, Windows + WSL checklists), see **[Zebrad ↔ NozyWallet connectivity](../../../docs/reference/ZEBRAD_NOZYWALLET_CONNECTIVITY.md)** in the repo docs. For **Zakura**, see **[Zakura ↔ NozyWallet connectivity](../../../docs/reference/ZAKURA_NOZYWALLET_CONNECTIVITY.md)** and the [Zakura book chapter](zakura-node.md).
 
 ---
 

--- a/book/src/cli/advanced-commands.md
+++ b/book/src/cli/advanced-commands.md
@@ -2,7 +2,7 @@
 
 ## `nozy test-zebra`
 
-Verify JSON-RPC to Zebrad (or Crosslink if configured).
+Verify JSON-RPC to Zebrad, **Zakura**, or Crosslink (if configured). Detects node kind from `getnetworkinfo` and probes `z_gettreestate` at tip.
 
 ```bash
 nozy test-zebra

--- a/book/src/faq/general.md
+++ b/book/src/faq/general.md
@@ -23,7 +23,7 @@ Mainnet and testnet — configure via `nozy config` or Settings.
 
 ## Do I need my own node?
 
-Strongly recommended. Wallet needs Zebrad JSON-RPC; see [Zebra Node Setup](../advanced/zebra-node.md).
+Strongly recommended. Wallet needs a Zebra-family JSON-RPC node ([Zebrad](https://github.com/ZcashFoundation/zebra) or [Zakura](https://zakura.com/)); see [Zebra Node Setup](../advanced/zebra-node.md) or [Zakura Node Setup](../advanced/zakura-node.md).
 
 ## Where is data stored?
 

--- a/book/src/getting-started/installation.md
+++ b/book/src/getting-started/installation.md
@@ -37,7 +37,7 @@ For advanced users, developers, or automated systems, you can use the CLI versio
 ### Prerequisites
 
 - **Rust 1.70+** - Install from [rustup.rs](https://rustup.rs/)
-- **Zebra RPC node** - Running on `http://127.0.0.1:8232` (or configure custom URL)
+- **Zebra-family RPC node** — [Zebrad](https://github.com/ZcashFoundation/zebra) or [Zakura](https://zakura.com/) on `http://127.0.0.1:8232` (or configure a custom URL). See [Zebra Node Setup](../advanced/zebra-node.md) or [Zakura Node Setup](../advanced/zakura-node.md).
 
 ### Build from Source
 

--- a/desktop-client/src/components/settings/NetworkSettings.tsx
+++ b/desktop-client/src/components/settings/NetworkSettings.tsx
@@ -78,7 +78,25 @@ export function NetworkSettings({ onBack }: NetworkSettingsProps) {
 
       <h2 className="text-3xl font-bold text-gray-900 dark:text-gray-100 mb-2">Network & Node</h2>
       <p className="text-gray-500 dark:text-gray-400 mb-8">
-        Configure your connection to a Zebra (Zcash) node for syncing and sending.
+        Configure your connection to a full node for syncing and sending. Use{" "}
+        <a
+          href="https://github.com/ZcashFoundation/zebra"
+          className="text-emerald-600 dark:text-emerald-400 underline"
+          target="_blank"
+          rel="noreferrer"
+        >
+          Zebrad
+        </a>{" "}
+        or{" "}
+        <a
+          href="https://zakura.com/"
+          className="text-emerald-600 dark:text-emerald-400 underline"
+          target="_blank"
+          rel="noreferrer"
+        >
+          Zakura
+        </a>{" "}
+        JSON-RPC (same port and URL field).
       </p>
 
       <div className="space-y-6">
@@ -102,7 +120,7 @@ export function NetworkSettings({ onBack }: NetworkSettingsProps) {
             </p>
           )}
           <Input
-            label="Zebra node RPC URL"
+            label="Full node RPC URL (Zebrad or Zakura)"
             value={url}
             onChange={(e) => setUrl(e.target.value)}
             placeholder={
@@ -117,14 +135,14 @@ export function NetworkSettings({ onBack }: NetworkSettingsProps) {
                 <>
                   Local testnet:{" "}
                   <code className="bg-black/5 dark:bg-white/10 px-1 rounded">http://127.0.0.1:18232</code>. WSL
-                  Zebrad: use the WSL IP, e.g.{" "}
+                  node: use the WSL IP, e.g.{" "}
                   <code className="bg-black/5 dark:bg-white/10 px-1 rounded">http://172.x.x.x:18232</code>.
                 </>
               ) : (
                 <>
                   Local mainnet:{" "}
                   <code className="bg-black/5 dark:bg-white/10 px-1 rounded">http://127.0.0.1:8232</code>. Remote
-                  Zebrad: use that PC&apos;s IP on the same port.
+                  node: use that host&apos;s IP on the same port.
                 </>
               )}
             </span>

--- a/docs/reference/ZAKURA_NOZYWALLET_CONNECTIVITY.md
+++ b/docs/reference/ZAKURA_NOZYWALLET_CONNECTIVITY.md
@@ -1,0 +1,164 @@
+# Zakura ↔ NozyWallet connectivity
+
+**Status:** Operator guide — July 2026  
+**Audience:** NozyWallet users who run their own [Zakura](https://zakura.com/) node  
+**Stack:** Zakurad JSON-RPC + lightwalletd + NozyWallet (CLI, desktop, api-server, mobile)
+
+NozyWallet does **not** bundle Zakura. This guide is for users who install and operate `zakurad` themselves.
+
+**Related:**
+
+| Doc | Role |
+|-----|------|
+| [`ZEBRAD_NOZYWALLET_CONNECTIVITY.md`](ZEBRAD_NOZYWALLET_CONNECTIVITY.md) | Same wallet wiring for Zebrad (config keys are shared) |
+| [`ZEBRAD_SHIELDED_SEND_LIMIT.md`](../../ZEBRAD_SHIELDED_SEND_LIMIT.md) | Witness derivation stays in the wallet |
+| [Zakura lightwalletd book](https://github.com/zakura-core/zakura/blob/v1.0.0/book/src/user/lightwalletd.md) | Upstream node + LWD setup |
+
+---
+
+## Executive summary
+
+1. **Zakura is a Zebra fork** — NozyWallet uses the same JSON-RPC surface (`z_gettreestate`, `sendrawtransaction`, `getblock`, …). Point `zebra_url` at Zakura’s RPC port.
+2. **Do not use zcashd compat mode** for NozyWallet — that path is for legacy `zcashd` wallet RPC (exchanges). Nozy keeps keys locally and speaks Zebra-family RPC.
+3. **Run lightwalletd against Zakura** for compact sync — same as Zebrad. Disable Zakura RPC cookie auth when lightwalletd connects (or use Zakura’s `docker-compose.lwd.yml`).
+4. **Cookie auth:** Zakura enables RPC cookies by default. Nozy reads `~/.cache/zakura/.cookie` automatically, or set `ZAKURA_RPC_COOKIE` / disable auth for local dev.
+
+---
+
+## What NozyWallet needs from the node
+
+| RPC / service | NozyWallet use |
+|---------------|----------------|
+| `getblockcount` | Tip, sync progress, send readiness |
+| `z_gettreestate` | Orchard/Ironwood witness checkpoints |
+| `z_getsubtreesbyindex` | Subtree sync (when used) |
+| `getblock` (verbose) | RPC scan path |
+| `sendrawtransaction` | Broadcast |
+| **lightwalletd** gRPC | Compact-block sync (`zeaking::lwd`) |
+
+Orchard witnesses are **not** served by the node — derived locally in the wallet.
+
+---
+
+## Quick setup (mainnet, Linux / WSL)
+
+### 1. Install and configure Zakura
+
+```bash
+zakurad generate -o ~/.config/zakurad.toml
+```
+
+Edit `~/.config/zakurad.toml`:
+
+```toml
+[rpc]
+listen_addr = "127.0.0.1:8232"
+enable_cookie_auth = false   # required for lightwalletd; OK for local-only dev
+```
+
+Start sync:
+
+```bash
+zakurad start
+```
+
+**Faster bootstrap:** use [Zakura snapshots](https://zakura.com/snapshots/) instead of full P2P sync.
+
+### 2. lightwalletd
+
+Follow [Zakura’s lightwalletd guide](https://github.com/zakura-core/zakura/blob/v1.0.0/book/src/user/lightwalletd.md). Minimal flow:
+
+```bash
+git clone https://github.com/zcash/lightwalletd
+cd lightwalletd && make && make install
+touch ~/.config/zcash.conf   # empty OK when RPC is 127.0.0.1:8232
+lightwalletd --zcash-conf-path ~/.config/zcash.conf \
+  --data-dir ~/.cache/lightwalletd --log-file /dev/stdout
+```
+
+Default gRPC: `127.0.0.1:9067`
+
+**Docker:** `docker compose -f docker/docker-compose.lwd.yml up` from the [zakura-core/zakura](https://github.com/zakura-core/zakura) repo (RPC + cookie settings preconfigured).
+
+### 3. Point NozyWallet at Zakura
+
+```bash
+nozy config --set-zebra-url http://127.0.0.1:8232
+export LIGHTWALLETD_GRPC=http://127.0.0.1:9067   # api-server / sync
+nozy test-zebra
+nozy sync --to-tip
+```
+
+`nozy test-zebra` detects **Zakura** from `getnetworkinfo` subversion and probes `z_gettreestate` at tip.
+
+---
+
+## RPC authentication (cookie)
+
+When `enable_cookie_auth = true` (Zakura default):
+
+| Method | Usage |
+|--------|--------|
+| Auto cookie file | `%USERPROFILE%\.cache\zakura\.cookie` (Windows) or `~/.cache/zakura/.cookie` (Linux) |
+| Env inline | `ZAKURA_RPC_COOKIE=user:password` (contents of `.cookie` file) |
+| Env path | `ZAKURA_RPC_COOKIE_PATH=/path/to/.cookie` |
+
+Zebrad cookie env vars (`ZEBRA_RPC_COOKIE`, etc.) still work for Zebrad-only setups.
+
+For **lightwalletd**, Zakura docs require `enable_cookie_auth = false` because lightwalletd does not send cookies.
+
+---
+
+## Windows + WSL
+
+Same pattern as Zebrad:
+
+1. Run `zakurad` + `lightwalletd` inside WSL.
+2. From Windows PowerShell:
+
+```powershell
+wsl hostname -I   # note WSL IP
+nozy config --set-zebra-url http://<wsl-ip>:8232
+$env:LIGHTWALLETD_GRPC = "http://<wsl-ip>:9067"
+nozy test-zebra
+```
+
+Smoke script: `.\scripts\test-zakura-nozywallet.ps1`
+
+---
+
+## Verify connectivity
+
+| Check | Command |
+|-------|---------|
+| RPC tip | `nozy test-zebra` — should show **Zakura** subversion |
+| Treestate probe | Included in `test-zebra` (`z_gettreestate` at tip) |
+| Compact sync | `nozy sync --to-tip` or desktop **Sync** |
+| Full smoke (Windows) | `.\scripts\test-zakura-nozywallet.ps1` |
+
+---
+
+## Zakura vs zcashd compat (do not mix up)
+
+| Mode | For | NozyWallet? |
+|------|-----|-------------|
+| **Zakurad JSON-RPC** (`listen_addr = :8232`) | Wallets, lightwalletd, explorers | **Yes** |
+| **zcashd compat** (`zakurad start --zcashd-compat`) | Legacy `zcashd` wallet RPC | **No** |
+
+---
+
+## Troubleshooting
+
+| Problem | What to try |
+|---------|-------------|
+| Connection refused on `:8232` | Enable `[rpc] listen_addr` in `zakurad.toml`; RPC is **off** by default in Docker unless configured |
+| 401 / auth errors | Set `ZAKURA_RPC_COOKIE` or disable `enable_cookie_auth` locally |
+| `test-zebra` OK but sync fails | Is lightwalletd running on `:9067`? Is `LIGHTWALLETD_GRPC` set for api-server? |
+| Treestate probe fails | Node not synced to tip; or RPC missing Orchard/Ironwood treestate (upgrade Zakura) |
+| Send fails after “synced” | Witness lag — rescan; see [`ZEBRAD_SHIELDED_SEND_LIMIT.md`](../../ZEBRAD_SHIELDED_SEND_LIMIT.md) |
+
+---
+
+## Status and testing
+
+Zakura 1.0.0 is a **new** node release ([announcement](https://zakura.com/announcements/introducing-zakura/)). NozyWallet targets the shared Zebra-family RPC contract; use `nozy test-zebra` (detects Zakura + probes treestate) before sync or send.

--- a/docs/reference/ZEBRAD_NOZYWALLET_CONNECTIVITY.md
+++ b/docs/reference/ZEBRAD_NOZYWALLET_CONNECTIVITY.md
@@ -11,13 +11,14 @@
 | [`MAINNET_SEND_READINESS_EVIDENCE.md`](MAINNET_SEND_READINESS_EVIDENCE.md) | Mainnet send timings assume a **live** Zebrad RPC |
 | [`../issues/bugs/2026-06-desktop-pre-release-debug-session.md`](../issues/bugs/2026-06-desktop-pre-release-debug-session.md) | NET_001 RCA, Windows `zebrad.toml` path, port 8232 vs 18232 |
 | [`../../ZEBRAD_SHIELDED_SEND_LIMIT.md`](../../ZEBRAD_SHIELDED_SEND_LIMIT.md) | What Zebrad does **not** provide (Orchard witnesses) |
+| [`ZAKURA_NOZYWALLET_CONNECTIVITY.md`](ZAKURA_NOZYWALLET_CONNECTIVITY.md) | Same wallet wiring for [Zakura](https://zakura.com/) users |
 | [`../../book/src/advanced/zebra-node.md`](../../book/src/advanced/zebra-node.md) | User-facing book chapter (summary + link here) |
 
 ---
 
 ## Executive summary (lecture slide)
 
-1. **NozyWallet is not a full node** — it needs a reachable **Zebrad JSON-RPC** endpoint for chain tip, broadcast, and treestate.
+1. **NozyWallet is not a full node** — it needs a reachable **Zebrad or Zakura JSON-RPC** endpoint for chain tip, broadcast, and treestate.
 2. **Connectivity is config-driven** — `zebra_url` in `config.json`, overridable by `ZEBRA_RPC_URL`.
 3. **“Connected” means `getblockcount` works** — run `nozy test-zebra` before sync or send.
 4. **Windows + WSL is a common layout** — Zebrad in Linux, wallet on Windows; use the **WSL IP**, not `127.0.0.1`, unless localhost forwarding is explicitly set up.

--- a/landing/src/components/DownloadSection.tsx
+++ b/landing/src/components/DownloadSection.tsx
@@ -35,7 +35,7 @@ const DownloadSection = () => {
           </div>
           <p className="text-sm text-zinc-600 mb-4">
             Orchard-first <code className="text-xs bg-zinc-100 px-1 rounded">nozy</code> binary.
-            Pair with your own <strong>zebrad</strong> + <strong>lightwalletd</strong>.
+            Pair with your own <strong>zebrad</strong> or <strong>Zakura</strong> + <strong>lightwalletd</strong>.
             On Linux / macOS run{" "}
             <code className="text-xs bg-zinc-100 px-1 rounded">chmod +x</code> after download.
           </p>

--- a/landing/src/components/ProductSurfaces.tsx
+++ b/landing/src/components/ProductSurfaces.tsx
@@ -35,7 +35,7 @@ const surfaces: Surface[] = [
   {
     icon: Bolt,
     title: "CLI Lite",
-    tagline: "Production-ready shielded ZEC on your own Zebrad + lightwalletd.",
+    tagline: "Production-ready shielded ZEC on your own Zebrad or Zakura + lightwalletd.",
     status: "live",
     statusLabel: "Mainnet ready",
     bullets: [
@@ -95,7 +95,7 @@ const surfaces: Surface[] = [
     status: "soon",
     statusLabel: "In development",
     bullets: [
-      "Connects to nozywallet-api on PC or VPS",
+      "Connects to nozywallet-api on PC or VPS + Zebrad/Zakura",
       "Business / Sell mode on the roadmap",
       "App Store and Play when ready",
     ],

--- a/nozy-mobile/src/components/settings/NetworkSettings.tsx
+++ b/nozy-mobile/src/components/settings/NetworkSettings.tsx
@@ -74,7 +74,7 @@ export function NetworkSettings({ onBack }: Props) {
   async function persistUrl(url: string) {
     const trimmed = url.trim();
     if (!trimmed) {
-      const msg = "Enter a Zebra RPC URL before saving.";
+      const msg = "Enter a full-node RPC URL before saving.";
       setError(msg);
       Alert.alert("Cannot save", msg);
       return;
@@ -102,7 +102,7 @@ export function NetworkSettings({ onBack }: Props) {
       setZebraUrl(trimmed);
       setInitialZebraUrl(trimmed);
       setNodeMode(inferNodeConnectionMode(trimmed));
-      const ok = `Zebra URL saved on the API:\n${trimmed}`;
+      const ok = `Full-node RPC URL saved on the API:\n${trimmed}`;
       setStatus(ok);
       Alert.alert("Saved", ok);
     } catch (e) {
@@ -158,7 +158,7 @@ export function NetworkSettings({ onBack }: Props) {
             () =>
               reject(
                 new Error(
-                  "Test timed out. The API could not reach that Zebrad (127.0.0.1 only works if Zebrad runs on the same machine as the API).",
+                  "Test timed out. The API could not reach that node (127.0.0.1 only works if Zebrad/Zakura runs on the same machine as the API).",
                 ),
               ),
             20000,
@@ -166,11 +166,11 @@ export function NetworkSettings({ onBack }: Props) {
         ),
       ]);
       setStatus(res.message);
-      Alert.alert(res.ok ? "Zebra OK" : "Zebra test", res.message);
+      Alert.alert(res.ok ? "Node OK" : "Node test", res.message);
     } catch (e) {
       const msg = e instanceof Error ? e.message : "Connection test failed";
       setError(msg);
-      Alert.alert("Zebra test failed", msg);
+      Alert.alert("Node test failed", msg);
     } finally {
       setLoading(false);
     }
@@ -185,23 +185,24 @@ export function NetworkSettings({ onBack }: Props) {
         <SettingsBackButton onPress={onBack} />
         <Text style={styles.title}>Network & Node</Text>
         <Text style={styles.subtitle}>
-          This sets the Zebrad URL on your API server (not on the phone). Local
-          node means the API machine’s localhost — only works if Zebrad runs
-          next to that API.
+          This sets the full-node RPC URL on your API server (not on the phone).
+          Use Zebrad or Zakura JSON-RPC (same port). Local node means the API
+          machine’s localhost — only works if the node runs next to that API.
         </Text>
         {apiIsHosted ? (
           <View style={styles.banner}>
             <Text style={styles.bannerText}>
               You are on the Nozy hosted API. http://127.0.0.1 here is the
               DigitalOcean box, not your phone or home PC. To use your node,
-              switch Mobile connection to your own API that sits next to Zebrad.
+              switch Mobile connection to your own API that sits next to
+              Zebrad/Zakura.
             </Text>
           </View>
         ) : null}
         <Card>
           <Text style={styles.meta}>Network: {network || "…"}</Text>
           <Select
-            label="Node type (API server → Zebrad)"
+            label="Node type (API server → Zebrad/Zakura)"
             value={nodeMode}
             options={[
               { value: "local", label: "Local / own node (recommended)" },
@@ -212,14 +213,14 @@ export function NetworkSettings({ onBack }: Props) {
           {nodeMode === "public" ? (
             <View style={styles.banner}>
               <Text style={styles.bannerText}>
-                Public Zebrad: the operator may log server-side sync and
-                broadcast timing. Nym smolmix only helps when submit goes to a
-                remote node you do not control.
+                Public node: the operator may log server-side sync and broadcast
+                timing. Nym smolmix only helps when submit goes to a remote node
+                you do not control.
               </Text>
             </View>
           ) : null}
           <Input
-            label="Zebra RPC URL"
+            label="Full node RPC URL (Zebrad or Zakura)"
             value={zebraUrl}
             onChangeText={setZebraUrl}
             autoCapitalize="none"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,6 +1,6 @@
 # Nozy-wallet helper scripts
 
-**Windows:** **Run Zebrad only in WSL** — do not run a separate native Windows Zebrad for Nozy development. If you **already have a synced Zebrad** in WSL (or elsewhere), skip installing another; just set Nozy’s RPC URL to that node.
+**Windows:** **Run Zebrad or Zakurad in WSL** — do not run a separate native Windows node for Nozy development unless you intend to. If you **already have a synced node** in WSL (or elsewhere), skip installing another; just set Nozy’s RPC URL to that node.
 
 PowerShell / bash helpers for **Nozy** (CLI, desktop, `api-server` / zeaking companion, WSL). **Zebrad node** launchers live in your [Zebrad](https://github.com/ZcashFoundation/zebra) checkout (`C:\Zebrad\scripts\start-zebrad-wsl.ps1`) — see Zebrad `scripts/README.md`.
 
@@ -24,6 +24,8 @@ PowerShell / bash helpers for **Nozy** (CLI, desktop, `api-server` / zeaking com
 | `run-nozy-api.sh` | WSL/Linux: start **`nozywallet-api`**. Auto-picks port **3000–3100** or set **`NOZY_HTTP_PORT`**. |
 | `build-release.ps1` / `build-release.sh` | Release build helpers. |
 | `nozy-lite-bench.ps1` | Measure Nozy Lite CLI size / `--version` / `health` timings for [`docs/reference/NOZY_LITE_BENCHES.md`](../docs/reference/NOZY_LITE_BENCHES.md). |
+| `test-zebrad-nozywallet.ps1` | Windows Zebrad + config smoke test |
+| `test-zakura-nozywallet.ps1` | Windows Zakurad + treestate + LWD smoke test |
 
 **Do not** run `run-nozy-api.ps1` from **bash** — use **`bash scripts/run-nozy-api.sh`** instead.
 

--- a/scripts/test-zakura-nozywallet.ps1
+++ b/scripts/test-zakura-nozywallet.ps1
@@ -1,0 +1,138 @@
+# Zakurad <-> NozyWallet connectivity smoke test (console output only)
+$ErrorActionPreference = "Continue"
+$RepoRoot = Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path)
+
+Write-Host ""
+Write-Host "Zakurad <-> NozyWallet connectivity test"
+Write-Host ""
+
+$configPath = Join-Path $env:APPDATA "nozy\nozy\config\config.json"
+$configZebraUrl = $null
+
+if (Test-Path $configPath) {
+    try {
+        $raw = [System.IO.File]::ReadAllText($configPath)
+        if ($raw.StartsWith([char]0xFEFF)) { $raw = $raw.Substring(1) }
+        $cfg = $raw | ConvertFrom-Json
+        $configZebraUrl = $cfg.zebra_url
+        Write-Host "Config: $configPath"
+        Write-Host "  zebra_url: $configZebraUrl"
+    } catch {
+        Write-Host "Config: failed to parse $configPath"
+    }
+} else {
+    Write-Host "Config: not found at $configPath"
+}
+
+function Invoke-NodeRpc {
+    param([string]$Url, [string]$Method, [object[]]$Params = @())
+    $body = @{ jsonrpc = "2.0"; method = $Method; params = $Params; id = 1 } | ConvertTo-Json -Compress
+    return Invoke-RestMethod -Uri $Url -Method POST -ContentType "application/json" -Body $body -TimeoutSec 15
+}
+
+function Test-RpcTip {
+    param([string]$Url, [string]$Label)
+    try {
+        $r = Invoke-NodeRpc -Url $Url -Method "getblockcount"
+        return @{ ok = $true; tip = [int]$r.result; url = $Url; label = $Label }
+    } catch {
+        return @{ ok = $false; url = $Url; label = $Label; error = $_.Exception.Message }
+    }
+}
+
+function Test-Subversion {
+    param([string]$Url)
+    try {
+        $r = Invoke-NodeRpc -Url $Url -Method "getnetworkinfo"
+        $sub = $r.result.subversion
+        $kind = if ($sub -match "zakura") { "Zakura" } elseif ($sub -match "zebra") { "Zebra" } else { "unknown" }
+        return @{ ok = $true; subversion = $sub; kind = $kind }
+    } catch {
+        return @{ ok = $false; error = $_.Exception.Message }
+    }
+}
+
+function Test-Treestate {
+    param([string]$Url, [int]$Height)
+    try {
+        $r = Invoke-NodeRpc -Url $Url -Method "z_gettreestate" -Params @([string]$Height)
+        $orchard = $r.result.orchard
+        if (-not $orchard) {
+            return @{ ok = $false; error = "z_gettreestate missing orchard section" }
+        }
+        return @{ ok = $true }
+    } catch {
+        return @{ ok = $false; error = $_.Exception.Message }
+    }
+}
+
+Write-Host ""
+$targets = @(
+    @{ label = "config_zebra_url"; url = $configZebraUrl },
+    @{ label = "localhost_8232"; url = "http://127.0.0.1:8232" }
+)
+
+$wslIp = (wsl hostname -I 2>$null)
+if ($wslIp) {
+    $wslIp = ($wslIp -split "\s+")[0].Trim()
+    if ($wslIp) {
+        $targets += @{ label = "wsl_dynamic"; url = "http://${wslIp}:8232" }
+    }
+}
+
+$seen = @{}
+$workingUrl = $null
+foreach ($t in ($targets | Where-Object { $_.url })) {
+    if ($seen.ContainsKey($t.url)) { continue }
+    $seen[$t.url] = $true
+    $res = Test-RpcTip -Url $t.url -Label $t.label
+    if ($res.ok) {
+        Write-Host "[OK]   $($t.label) $($t.url) tip=$($res.tip)"
+        if (-not $workingUrl) { $workingUrl = $t.url }
+        $sv = Test-Subversion -Url $t.url
+        if ($sv.ok) {
+            Write-Host "       node=$($sv.kind) subversion=$($sv.subversion)"
+            $ts = Test-Treestate -Url $t.url -Height $res.tip
+            if ($ts.ok) {
+                Write-Host "       z_gettreestate(orchard) at tip: OK"
+            } else {
+                Write-Host "       z_gettreestate at tip: FAIL - $($ts.error)"
+            }
+        }
+    } else {
+        Write-Host "[FAIL] $($t.label) $($t.url) - $($res.error)"
+    }
+}
+
+# lightwalletd gRPC port (TCP only)
+$lwdUp = $false
+try {
+    $tcp = New-Object System.Net.Sockets.TcpClient
+    $tcp.Connect("127.0.0.1", 9067)
+    $lwdUp = $true
+    $tcp.Close()
+} catch {}
+Write-Host ""
+Write-Host ("lightwalletd :9067  {0}" -f $(if ($lwdUp) { "UP" } else { "DOWN" }))
+
+$nozy = Join-Path $RepoRoot "target\release\nozy.exe"
+if (-not (Test-Path $nozy)) {
+    $nozy = Join-Path $RepoRoot "nozy.exe"
+}
+
+Write-Host ""
+if (Test-Path $nozy) {
+    Write-Host "nozy test-zebra:"
+    & $nozy test-zebra
+} else {
+    Write-Host "nozy.exe not found - build with: cargo build --release --bin nozy"
+}
+
+$zakurad = Get-Process zakurad -ErrorAction SilentlyContinue
+$zebrad = Get-Process zebrad -ErrorAction SilentlyContinue
+Write-Host ""
+Write-Host "Windows zakurad process: $(if ($zakurad) { "running (PID $($zakurad.Id))" } else { "not running" })"
+Write-Host "Windows zebrad process:  $(if ($zebrad) { "running (PID $($zebrad.Id))" } else { "not running" })"
+Write-Host ""
+Write-Host "Guide: docs/reference/ZAKURA_NOZYWALLET_CONNECTIVITY.md"
+Write-Host ""

--- a/src/bin/diagnose_zebra.rs
+++ b/src/bin/diagnose_zebra.rs
@@ -3,7 +3,7 @@ use std::env;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    println!("🔍 Zebra Node RPC Diagnostic Tool");
+    println!("🔍 Zebra / Zakura node RPC diagnostic tool");
     println!("==================================\n");
 
     // Get Zebra URL from command line or use default

--- a/src/main.rs
+++ b/src/main.rs
@@ -1603,8 +1603,9 @@ async fn execute_command(_command: Commands, mut config: nozy::WalletConfig) -> 
                 Ok(_) => {
                     println!();
                     println!("🎉 Connection successful!");
+                    let kind = client.detect_chain_node_kind().await;
                     let backend_name = match config.backend {
-                        nozy::BackendKind::Zebra => "Zebra",
+                        nozy::BackendKind::Zebra => kind.label(),
                         nozy::BackendKind::Crosslink => "Crosslink",
                     };
                     let is_local = test_url.contains("127.0.0.1") || test_url.contains("localhost");
@@ -1619,6 +1620,19 @@ async fn execute_command(_command: Commands, mut config: nozy::WalletConfig) -> 
                             backend_name
                         );
                     }
+
+                    match client.probe_wallet_treestate().await {
+                        Ok(_) => {
+                            println!("✅ z_gettreestate at tip OK (Orchard witness path ready)");
+                        }
+                        Err(e) => {
+                            println!("⚠️  z_gettreestate probe failed: {}", e);
+                            println!(
+                                "   Sync/send may fail until the node exposes Orchard treestate at tip."
+                            );
+                        }
+                    }
+
                     println!("✅ Ready to sync and send transactions!");
 
                     match client.get_network_info().await {
@@ -1628,6 +1642,9 @@ async fn execute_command(_command: Commands, mut config: nozy::WalletConfig) -> 
                             }
                             if let Some(blocks) = info.get("blocks") {
                                 println!("   Blocks: {:?}", blocks);
+                            }
+                            if let Some(subver) = info.get("subversion") {
+                                println!("   Subversion: {:?}", subver);
                             }
                         }
                         Err(_) => {}

--- a/src/zebra_integration.rs
+++ b/src/zebra_integration.rs
@@ -33,6 +33,37 @@ fn is_retryable_zebra_transport_error(msg: &str) -> bool {
         || m.contains("unexpected eof")
 }
 
+/// Detected full-node implementation behind the Zebra-family JSON-RPC surface.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ChainNodeKind {
+    Zebra,
+    Zakura,
+    Unknown,
+}
+
+impl ChainNodeKind {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Zebra => "Zebra",
+            Self::Zakura => "Zakura",
+            Self::Unknown => "Zcash node",
+        }
+    }
+
+    /// Classify from `getnetworkinfo` → `subversion` (or similar) string.
+    pub fn from_subversion(subversion: &str) -> Self {
+        let s = subversion.to_ascii_lowercase();
+        if s.contains("zakura") {
+            Self::Zakura
+        } else if s.contains("zebra") || s.contains("zebrad") {
+            Self::Zebra
+        } else {
+            Self::Unknown
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ZebraConnectionMode {
@@ -202,52 +233,62 @@ impl ZebraClient {
     fn candidate_cookie_paths() -> Vec<PathBuf> {
         let mut paths = Vec::new();
 
-        if let Ok(path) = std::env::var("ZEBRA_RPC_COOKIE_PATH") {
-            if !path.trim().is_empty() {
-                paths.push(PathBuf::from(path));
+        for env_key in ["ZEBRA_RPC_COOKIE_PATH", "ZAKURA_RPC_COOKIE_PATH"] {
+            if let Ok(path) = std::env::var(env_key) {
+                if !path.trim().is_empty() {
+                    paths.push(PathBuf::from(path));
+                }
             }
         }
 
-        if let Ok(cookie_inline) = std::env::var("ZEBRA_RPC_COOKIE") {
-            if let Some(pair) = Self::parse_cookie_pair(&cookie_inline) {
-                // Inline cookie env is handled in `resolve_rpc_auth`; no file path to add.
-                let _ = pair;
+        for env_key in ["ZEBRA_RPC_COOKIE", "ZAKURA_RPC_COOKIE"] {
+            if let Ok(cookie_inline) = std::env::var(env_key) {
+                if let Some(pair) = Self::parse_cookie_pair(&cookie_inline) {
+                    // Inline cookie env is handled in `resolve_rpc_auth`; no file path to add.
+                    let _ = pair;
+                }
             }
         }
 
-        if let Ok(home) = std::env::var("HOME") {
-            paths.push(
-                PathBuf::from(home)
-                    .join(".cache")
-                    .join("zebra")
-                    .join(".cookie"),
-            );
-        }
-        if let Ok(profile) = std::env::var("USERPROFILE") {
-            paths.push(
-                PathBuf::from(profile)
-                    .join(".cache")
-                    .join("zebra")
-                    .join(".cookie"),
-            );
+        for cache_name in ["zebra", "zakura"] {
+            if let Ok(home) = std::env::var("HOME") {
+                paths.push(
+                    PathBuf::from(&home)
+                        .join(".cache")
+                        .join(cache_name)
+                        .join(".cookie"),
+                );
+            }
+            if let Ok(profile) = std::env::var("USERPROFILE") {
+                paths.push(
+                    PathBuf::from(&profile)
+                        .join(".cache")
+                        .join(cache_name)
+                        .join(".cookie"),
+                );
+            }
         }
 
         paths
     }
 
     fn resolve_rpc_auth() -> Option<(String, String)> {
-        if let (Ok(user), Ok(pass)) = (
-            std::env::var("ZEBRA_RPC_USER"),
-            std::env::var("ZEBRA_RPC_PASS"),
-        ) {
-            if !user.trim().is_empty() && !pass.trim().is_empty() {
-                return Some((user, pass));
+        for (user_key, pass_key) in [
+            ("ZEBRA_RPC_USER", "ZEBRA_RPC_PASS"),
+            ("ZAKURA_RPC_USER", "ZAKURA_RPC_PASS"),
+        ] {
+            if let (Ok(user), Ok(pass)) = (std::env::var(user_key), std::env::var(pass_key)) {
+                if !user.trim().is_empty() && !pass.trim().is_empty() {
+                    return Some((user, pass));
+                }
             }
         }
 
-        if let Ok(cookie_inline) = std::env::var("ZEBRA_RPC_COOKIE") {
-            if let Some(pair) = Self::parse_cookie_pair(&cookie_inline) {
-                return Some(pair);
+        for env_key in ["ZEBRA_RPC_COOKIE", "ZAKURA_RPC_COOKIE"] {
+            if let Ok(cookie_inline) = std::env::var(env_key) {
+                if let Some(pair) = Self::parse_cookie_pair(&cookie_inline) {
+                    return Some(pair);
+                }
             }
         }
 
@@ -1094,6 +1135,26 @@ This blocks remote RPC only; localhost RPC remains allowed.",
         Ok(zebra_response)
     }
 
+    /// Detect node implementation from `getnetworkinfo` when available.
+    pub async fn detect_chain_node_kind(&self) -> ChainNodeKind {
+        match self.get_network_info().await {
+            Ok(info) => {
+                if let Some(Value::String(subver)) = info.get("subversion") {
+                    return ChainNodeKind::from_subversion(subver);
+                }
+            }
+            Err(_) => {}
+        }
+        ChainNodeKind::Unknown
+    }
+
+    /// NozyWallet-required RPC: treestate at chain tip (Orchard witness path).
+    pub async fn probe_wallet_treestate(&self) -> NozyResult<()> {
+        let height = self.get_block_count().await?;
+        self.get_orchard_treestate_parsed(height).await?;
+        Ok(())
+    }
+
     pub async fn test_connection(&self) -> NozyResult<()> {
         match self.protocol {
             Protocol::Grpc => {
@@ -1106,7 +1167,12 @@ This blocks remote RPC only; localhost RPC remains allowed.",
             }
             Protocol::JsonRpc => {
                 let block_count = self.get_block_count().await?;
-                println!("✅ Successfully connected to Zebra node at {}", self.url);
+                let kind = self.detect_chain_node_kind().await;
+                println!(
+                    "✅ Successfully connected to {} node at {}",
+                    kind.label(),
+                    self.url
+                );
                 println!("   Current block height: {}", block_count);
             }
         }
@@ -1283,6 +1349,27 @@ pub struct OrchardTreeState {
 
 /// Ironwood uses the Orchard note-commitment tree primitives with a separate pool/tree.
 pub type IronwoodTreeState = OrchardTreeState;
+
+#[cfg(test)]
+mod chain_node_kind_tests {
+    use super::ChainNodeKind;
+
+    #[test]
+    fn detects_zakura_subversion() {
+        assert_eq!(
+            ChainNodeKind::from_subversion("/Zakura:1.0.0/"),
+            ChainNodeKind::Zakura
+        );
+    }
+
+    #[test]
+    fn detects_zebra_subversion() {
+        assert_eq!(
+            ChainNodeKind::from_subversion("/Zebra:6.0.0/"),
+            ChainNodeKind::Zebra
+        );
+    }
+}
 
 #[cfg(test)]
 mod connection_policy_tests {


### PR DESCRIPTION
## Summary
- Treat [Zakura](https://zakura.com/) as a first-class Zebra-family JSON-RPC backend: detect node kind from `getnetworkinfo`, accept Zakura RPC cookie/auth env vars, and probe `z_gettreestate` from `nozy test-zebra`.
- Document the operator path (Zakurad + lightwalletd + same `zebra_url`) in the book and `docs/reference/ZAKURA_NOZYWALLET_CONNECTIVITY.md`, with a Windows smoke script.
- Update desktop/mobile Network settings and landing copy so Zebrad and Zakura share the same URL field.

## Test plan
- [ ] `cargo test --lib chain_node_kind_tests` (or `cargo test detects_zakura_subversion`)
- [ ] Against a local Zakurad: `nozy config --set-zebra-url http://127.0.0.1:8232` then `nozy test-zebra` (expect Zakura label + treestate OK)
- [ ] Optional: `.\scripts\test-zakura-nozywallet.ps1` with Zakurad (+ lightwalletd if testing sync)
- [ ] Desktop/mobile Settings → Network: labels mention Zebrad or Zakura; save/test still work against Zebrad

## AI disclosure
Drafted and landed with Cursor (Composer). Human author remains responsible for review and correctness.